### PR TITLE
restore original license in "de.scoopgmbh.copper.monitoring.client.util.dialogs.Dialogs"

### DIFF
--- a/projects/copper-monitoring/copper-monitoring-client/src/main/java/de/scoopgmbh/copper/monitoring/client/util/dialogs/Dialogs.java
+++ b/projects/copper-monitoring/copper-monitoring-client/src/main/java/de/scoopgmbh/copper/monitoring/client/util/dialogs/Dialogs.java
@@ -1,19 +1,28 @@
 // Code adapted from https://github.com/marcojakob/javafx-ui-sandbox
 
 /*
- * Copyright 2002-2013 SCOOP Software GmbH
+ * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 package de.scoopgmbh.copper.monitoring.client.util.dialogs;
 


### PR DESCRIPTION
We should not change the original license header! Whatever!
