### PR TITLE
Add factories for Processors to the PriorityProcessorPool

### DIFF
--- a/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/common/IProcessorFactory.java
+++ b/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/common/IProcessorFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2002-2013 SCOOP Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.scoopgmbh.copper.common;
+
+import de.scoopgmbh.copper.ProcessingEngine;
+import de.scoopgmbh.copper.Workflow;
+
+import java.util.Queue;
+
+public interface IProcessorFactory {
+    Processor newProcessor(String id, Queue<Workflow<?>> queue, int threadPrioriry, ProcessingEngine engine);
+}

--- a/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/common/PriorityProcessorPool.java
+++ b/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/common/PriorityProcessorPool.java
@@ -49,6 +49,8 @@ public abstract class PriorityProcessorPool implements ProcessorPool, ProcessorP
 	private boolean started = false;
 	private boolean shutdown = false;
 
+    protected IProcessorFactory processorFactory;
+
 	/**
 	 * Creates a new {@link PriorityProcessorPool} with as many worker threads as processors available on the corresponding environment.
 	 * <code>id</code> needs to be initialized later using the setter.
@@ -126,13 +128,11 @@ public abstract class PriorityProcessorPool implements ProcessorPool, ProcessorP
 			}
 		}
 		while (numberOfThreads > workerThreads.size()) {
-			Processor p = newProcessor(id+"#"+workerThreads.size(), queue, threadPriority, engine);
+			Processor p = processorFactory.newProcessor(id + "#" + workerThreads.size(), queue, threadPriority, engine);
 			p.start();
 			workerThreads.add(p);
 		}
 	}
-
-	protected abstract Processor newProcessor(String id, Queue<Workflow<?>> queue, int threadPrioriry, ProcessingEngine engine);
 
 	public synchronized int getNumberOfThreads() {
 		return numberOfThreads;
@@ -224,5 +224,9 @@ public abstract class PriorityProcessorPool implements ProcessorPool, ProcessorP
 			queue.setSuspended(true);
 		}
 	}
+
+    public void setProcessorFactory(IProcessorFactory processorFactory) {
+        this.processorFactory = processorFactory;
+    }
 
 }

--- a/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/persistent/PersistentPriorityProcessorPool.java
+++ b/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/persistent/PersistentPriorityProcessorPool.java
@@ -21,11 +21,9 @@ import java.util.Queue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.scoopgmbh.copper.ProcessingEngine;
 import de.scoopgmbh.copper.ProcessingState;
 import de.scoopgmbh.copper.Workflow;
 import de.scoopgmbh.copper.common.PriorityProcessorPool;
-import de.scoopgmbh.copper.common.Processor;
 import de.scoopgmbh.copper.common.WfPriorityQueue;
 import de.scoopgmbh.copper.internal.WorkflowAccessor;
 import de.scoopgmbh.copper.management.PersistentPriorityProcessorPoolMXBean;
@@ -40,7 +38,7 @@ import de.scoopgmbh.copper.persistent.txn.TransactionController;
 public class PersistentPriorityProcessorPool extends PriorityProcessorPool implements PersistentProcessorPool, PersistentPriorityProcessorPoolMXBean {
 
 	private static final Logger logger = LoggerFactory.getLogger(PersistentPriorityProcessorPool.class);
-	
+
 	private TransactionController transactionController;
 	
 	private Thread thread;
@@ -59,6 +57,7 @@ public class PersistentPriorityProcessorPool extends PriorityProcessorPool imple
 	 */
 	public PersistentPriorityProcessorPool() {
 		super();
+        processorFactory = new PersistentProcessorFactory();
 	}
 
 	/**
@@ -67,20 +66,18 @@ public class PersistentPriorityProcessorPool extends PriorityProcessorPool imple
 	public PersistentPriorityProcessorPool(String id, TransactionController transactionController) {
 		super(id);
 		this.transactionController = transactionController;
+        processorFactory = new PersistentProcessorFactory(transactionController);
 	}
 	
 	public PersistentPriorityProcessorPool(String id, TransactionController transactionController, int numberOfThreads) {
 		super(id, numberOfThreads);
 		this.transactionController = transactionController;
+        processorFactory = new PersistentProcessorFactory(transactionController);
 	}
 
 	public void setTransactionController(TransactionController transactionController) {
 		this.transactionController = transactionController;
-	}
-	
-	@Override
-	protected Processor newProcessor(String name, Queue<Workflow<?>> queue, int threadPriority, ProcessingEngine engine) {
-		return new PersistentProcessor(name, queue, threadPriority, engine, transactionController);
+        ((PersistentProcessorFactory)processorFactory).setTransactionController(transactionController);
 	}
 	
 	@Override

--- a/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/persistent/PersistentProcessorFactory.java
+++ b/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/persistent/PersistentProcessorFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2013 SCOOP Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.scoopgmbh.copper.persistent;
+
+import de.scoopgmbh.copper.ProcessingEngine;
+import de.scoopgmbh.copper.Workflow;
+import de.scoopgmbh.copper.common.IProcessorFactory;
+import de.scoopgmbh.copper.common.Processor;
+import de.scoopgmbh.copper.persistent.txn.TransactionController;
+
+import java.util.Queue;
+
+public class PersistentProcessorFactory implements IProcessorFactory {
+
+
+    private TransactionController transactionController;
+
+    public PersistentProcessorFactory(TransactionController transactionController){
+        this.transactionController = transactionController;
+    }
+
+    public PersistentProcessorFactory(){
+    }
+
+
+    public void setTransactionController(TransactionController transactionController) {
+        this.transactionController = transactionController;
+    }
+
+    public Processor newProcessor(String id, Queue<Workflow<?>> queue, int threadPrioriry, ProcessingEngine engine){
+        return new PersistentProcessor(id, queue, threadPrioriry, engine, transactionController);
+    }
+}

--- a/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/tranzient/TransientPriorityProcessorPool.java
+++ b/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/tranzient/TransientPriorityProcessorPool.java
@@ -38,6 +38,7 @@ public class TransientPriorityProcessorPool extends PriorityProcessorPool implem
 	 * <code>id</code> needs to be initialized later using the setter.
 	 */
 	public TransientPriorityProcessorPool() {
+        setProcessorFactory(new TransientProcessorFactory());
 	}
 	
 	/**
@@ -45,10 +46,12 @@ public class TransientPriorityProcessorPool extends PriorityProcessorPool implem
 	 */
 	public TransientPriorityProcessorPool(String id) {
 		super(id);
+        setProcessorFactory(new TransientProcessorFactory());
 	}
 	
 	public TransientPriorityProcessorPool(String id, int numberOfThreads) {
 		super(id, numberOfThreads);
+        setProcessorFactory(new TransientProcessorFactory());
 	}
 
 	@Override
@@ -64,9 +67,5 @@ public class TransientPriorityProcessorPool extends PriorityProcessorPool implem
 		}
 	}
 
-	@Override
-	protected Processor newProcessor(String name, Queue<Workflow<?>> queue, int threadPrioriry, ProcessingEngine engine) {
-		return new TransientProcessor(name,queue,threadPrioriry,engine);
-	}
 
 }

--- a/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/tranzient/TransientProcessorFactory.java
+++ b/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/tranzient/TransientProcessorFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2013 SCOOP Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.scoopgmbh.copper.tranzient;
+
+import de.scoopgmbh.copper.ProcessingEngine;
+import de.scoopgmbh.copper.Workflow;
+import de.scoopgmbh.copper.common.Processor;
+import de.scoopgmbh.copper.common.IProcessorFactory;
+
+import java.util.Queue;
+
+public class TransientProcessorFactory implements IProcessorFactory {
+
+    public TransientProcessorFactory(){
+    }
+
+
+    public Processor newProcessor(String id, Queue<Workflow<?>> queue, int threadPrioriry, ProcessingEngine engine){
+        return new TransientProcessor(id,queue,threadPrioriry,engine);
+    }
+}


### PR DESCRIPTION
This adds a processorFactory to the PriorityProcessorPool and removes the abstract newProcessor() method.
