### PR TITLE
extract setting of the MDC in the Processor to a processing hook.

### DIFF
--- a/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/common/IProcessingHook.java
+++ b/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/common/IProcessingHook.java
@@ -1,0 +1,9 @@
+package de.scoopgmbh.copper.common;
+
+import de.scoopgmbh.copper.Workflow;
+
+public interface IProcessingHook {
+
+     void postProcess(Workflow<?> wf);
+     void preProcess(Workflow<?> wf);
+}

--- a/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/common/MDCProcessingHook.java
+++ b/projects/copper-coreengine/src/main/java/de/scoopgmbh/copper/common/MDCProcessingHook.java
@@ -1,0 +1,19 @@
+package de.scoopgmbh.copper.common;
+
+
+import de.scoopgmbh.copper.Workflow;
+import de.scoopgmbh.copper.util.MDCConstants;
+import org.slf4j.MDC;
+
+public class MDCProcessingHook implements IProcessingHook {
+
+    @Override
+    public void postProcess(Workflow<?> wf) {
+        MDC.remove(MDCConstants.REQUEST);
+    }
+
+    @Override
+    public void preProcess(Workflow<?> wf) {
+        MDC.put(MDCConstants.REQUEST, wf.getId());
+    }
+}


### PR DESCRIPTION
A copper user might want so set additional custom data in the MDC which might be more meaningful to him than the plain request id.
