### PR TITLE
do not do the replace_header with every compile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,6 @@ configure(subprojects.findAll { new File(it.projectDir, 'src/main/java').directo
             }
         }
     }
-    compileJava.dependsOn replace_headers    
     
     
     /// ********


### PR DESCRIPTION
If we expect external developer to ever contribute to copper, the build should not blindly overwrite the license header,
because the copyright of the contribution remains typically with the author.

Blindly overwriting license headers in an open source project seems like a very unfriendly thing to me.
