### PR TITLE
add getter for "registerCall" to PersistentWorkflow.

### DIFF
--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentProcessor.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentProcessor.java
@@ -63,8 +63,8 @@ public class PersistentProcessor extends Processor {
                         } finally {
                             engine.unregister(pw);
                         }
-                        if (pw.registerCall != null) {
-                            engine.getDbStorage().registerCallback(pw.registerCall, new Acknowledge.BestEffortAcknowledge());
+                        if (pw.getRegisterCall() != null) {
+                            engine.getDbStorage().registerCallback(pw.getRegisterCall(), new Acknowledge.BestEffortAcknowledge());
                         }
                     }
                     return null;

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentWorkflow.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentWorkflow.java
@@ -60,6 +60,10 @@ public abstract class PersistentWorkflow<E extends Serializable> extends Workflo
         responseIdList.add(responseId);
     }
 
+    public RegisterCall getRegisterCall() {
+        return registerCall;
+    }
+
     /**
      * Used internally
      */


### PR DESCRIPTION
The registerCall member is used by the Processor. Under special circumstances a copper user might want to create
a custom Processor implementation. Because the registerCall member is package protected, the user is forced to put the custom processor
implementation in the "org.copperengine.core.persistent" package. Which is quite annoying.
