### PR TITLE
Typo in method name: getMonitroingDataStorageInfo

### DIFF
--- a/projects/copper-monitoring/copper-monitoring-client/src/main/java/org/copperengine/monitoring/client/adapter/GuiCopperDataProvider.java
+++ b/projects/copper-monitoring/copper-monitoring-client/src/main/java/org/copperengine/monitoring/client/adapter/GuiCopperDataProvider.java
@@ -489,7 +489,7 @@ public class GuiCopperDataProvider {
 
     public MonitoringDataStorageInfo getMonitoringStorageInfo() {
         try {
-            return copperMonitoringService.getMonitroingDataStorageInfo();
+            return copperMonitoringService.getMonitoringDataStorageInfo();
         } catch (RemoteException e) {
             throw new RuntimeException(e);
         }

--- a/projects/copper-monitoring/copper-monitoring-client/src/test/java/org/copperengine/monitoring/client/screenshotgen/view/fixture/TestDataProvider.java
+++ b/projects/copper-monitoring/copper-monitoring-client/src/test/java/org/copperengine/monitoring/client/screenshotgen/view/fixture/TestDataProvider.java
@@ -1244,4 +1244,10 @@ public class TestDataProvider implements CopperMonitoringService {
         return null;
     }
 
+    @Override
+    public MonitoringDataStorageInfo getMonitoringDataStorageInfo() throws RemoteException {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
 }

--- a/projects/copper-monitoring/copper-monitoring-core/src/main/java/org/copperengine/monitoring/core/CopperMonitoringService.java
+++ b/projects/copper-monitoring/copper-monitoring-core/src/main/java/org/copperengine/monitoring/core/CopperMonitoringService.java
@@ -106,7 +106,10 @@ public interface CopperMonitoringService extends Remote, Serializable, Monitorin
     public void startMonitoringDataProvider(String name) throws RemoteException;
 
     public void stopMonitoringDataProvider(String name) throws RemoteException;
-
+    
+    @Deprecated
+    /* will be removed in 4.0 */
     public MonitoringDataStorageInfo getMonitroingDataStorageInfo() throws RemoteException;
 
+    public MonitoringDataStorageInfo getMonitoringDataStorageInfo() throws RemoteException;
 }

--- a/projects/copper-monitoring/copper-monitoring-core/src/main/java/org/copperengine/monitoring/core/data/MonitoringDataAccessor.java
+++ b/projects/copper-monitoring/copper-monitoring-core/src/main/java/org/copperengine/monitoring/core/data/MonitoringDataAccessor.java
@@ -82,7 +82,13 @@ public class MonitoringDataAccessor implements MonitoringDataQuerys {
         return result;
     }
 
+    @Deprecated
+    /* will be removed in 4.0 */
     public MonitoringDataStorageInfo getMonitroingDataStorageInfo() {
-        return monitoringDataStorage.getMonitroingDataStorageInfo();
+        return getMonitoringDataStorageInfo();
+    }
+
+    public MonitoringDataStorageInfo getMonitoringDataStorageInfo() {
+        return monitoringDataStorage.getMonitoringDataStorageInfo();
     }
 }

--- a/projects/copper-monitoring/copper-monitoring-core/src/main/java/org/copperengine/monitoring/core/data/MonitoringDataStorage.java
+++ b/projects/copper-monitoring/copper-monitoring-core/src/main/java/org/copperengine/monitoring/core/data/MonitoringDataStorage.java
@@ -653,8 +653,14 @@ public class MonitoringDataStorage {
             return new Date(max);
         }
     }
-
+    
+    @Deprecated
+    /* will be removed in 4.0 */
     public MonitoringDataStorageInfo getMonitroingDataStorageInfo() {
+        return getMonitoringDataStorageInfo();
+    }
+
+    public MonitoringDataStorageInfo getMonitoringDataStorageInfo() {
 
         final HashMap<String, MonitoringDataStorageContentInfo> classToInfo = new HashMap<String, MonitoringDataStorageContentInfo>();
         for (MonitoringData data : read(null, null)) {

--- a/projects/copper-monitoring/copper-monitoring-server/src/main/java/org/copperengine/monitoring/server/DefaultCopperMonitoringService.java
+++ b/projects/copper-monitoring/copper-monitoring-server/src/main/java/org/copperengine/monitoring/server/DefaultCopperMonitoringService.java
@@ -454,15 +454,21 @@ public class DefaultCopperMonitoringService implements CopperMonitoringService {
     }
 
     @Override
+    @Deprecated
+    /* will be removed in 4.0 */
     public MonitoringDataStorageInfo getMonitroingDataStorageInfo() {
+        return getMonitoringDataStorageInfo();
+    }
+
+    @Override
+    public MonitoringDataStorageInfo getMonitoringDataStorageInfo() {
         return monitoringDataAccessQueue.callAndWait(new MonitoringDataAwareCallable<MonitoringDataStorageInfo>() {
             @Override
             public MonitoringDataStorageInfo call() throws Exception {
-                return monitoringDataAccesor.getMonitroingDataStorageInfo();
+                return monitoringDataAccesor.getMonitoringDataStorageInfo();
             }
         });
     }
-
 
 
 }


### PR DESCRIPTION
The getMonitroingDataStorageInfo() method is now deprecated and it will be removed in 4.0. It is replaced by getMonitoringDataStorageInfo().
