### PR TITLE
Restore java 6 compatibility for monitoring-client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -476,8 +476,8 @@ def javaHome = System.properties['java.home']
 project(':projects:copper-monitoring:copper-monitoring-client') {
     apply plugin: 'application'
 
-    compileJava.sourceCompatibility = JavaVersion.VERSION_1_7
-    compileJava.targetCompatibility = JavaVersion.VERSION_1_7
+    compileJava.sourceCompatibility = JavaVersion.VERSION_1_6
+    compileJava.targetCompatibility = JavaVersion.VERSION_1_6
 
     mainClassName = "org.copperengine.monitoring.client.main.MonitorMain"
 

--- a/projects/copper-monitoring/copper-monitoring-client/src/main/java/org/copperengine/monitoring/client/context/FormContext.java
+++ b/projects/copper-monitoring/copper-monitoring-client/src/main/java/org/copperengine/monitoring/client/context/FormContext.java
@@ -285,7 +285,7 @@ public class FormContext implements DashboardDependencyFactory, WorkflowInstance
             }
         };
         loadCreator.add(measurePointCreator);
-        if (!copperInterfaceSettings.getSupportedFeatures().isSupportsLoggingStatisticCollector()) {
+        if (copperInterfaceSettings.getSupportedFeatures() != null && !copperInterfaceSettings.getSupportedFeatures().isSupportsLoggingStatisticCollector()) {
             measurePointCreator.setEnabled(false);
             measurePointCreator.setTooltip(new Tooltip("not available in copper"));
         }

--- a/projects/copper-monitoring/copper-monitoring-client/src/main/java/org/copperengine/monitoring/client/form/filter/FilterResultControllerBase.java
+++ b/projects/copper-monitoring/copper-monitoring-client/src/main/java/org/copperengine/monitoring/client/form/filter/FilterResultControllerBase.java
@@ -62,8 +62,8 @@ import com.sun.javafx.scene.control.behavior.TableCellBehavior;
  */
 public abstract class FilterResultControllerBase<F, R> implements FilterResultController<F, R>, FxmlController {
 
-    private final List<TableView<?>> tableViews = new ArrayList<>();
-    private final Map<TableView<?>, ObservableList<?>> originalItemsMap = new HashMap<>(); 
+    private final List<TableView<?>> tableViews = new ArrayList<TableView<?>>();
+    private final Map<TableView<?>, ObservableList<?>> originalItemsMap = new HashMap<TableView<?>, ObservableList<?>>(); 
 
     public <M> HBox createTabelControlls(final TableView<M> tableView) {        
         this.tableViews.add(tableView);
@@ -105,7 +105,7 @@ public abstract class FilterResultControllerBase<F, R> implements FilterResultCo
         for(TableColumn<M, ?> column : tableView.getColumns()) {
             columnOptions.add(column.getText());
         }        
-        final ComboBox<String> columnField = new ComboBox<>(columnOptions);
+        final ComboBox<String> columnField = new ComboBox<String>(columnOptions);
         columnField.setPromptText("column");
         columnField.getSelectionModel().select(0);
         

--- a/projects/copper-monitoring/copper-monitoring-client/src/main/java/org/copperengine/monitoring/client/ui/settings/CssConfig.java
+++ b/projects/copper-monitoring/copper-monitoring-client/src/main/java/org/copperengine/monitoring/client/ui/settings/CssConfig.java
@@ -72,13 +72,13 @@ public class CssConfig {
     private CssConfig() {
         type = Type.CSS;
         for (int i = 0; i < COLOR_COUNT; i++) {
-            colorProperties[i] = new SimpleObjectProperty<>();
+            colorProperties[i] = new SimpleObjectProperty<Color>();
         }
     }
 
     public CssConfig(String cssUri) {
         for (int i = 0; i < COLOR_COUNT; i++) {
-            colorProperties[i] = new SimpleObjectProperty<>();
+            colorProperties[i] = new SimpleObjectProperty<Color>();
         }
         cssUri = get(cssUri, "LIGHT");
         String[] tokens = Arrays.copyOf(cssUri.split(":"), COLOR_COUNT + 1);

--- a/projects/copper-monitoring/copper-monitoring-client/src/main/java/org/copperengine/monitoring/client/ui/settings/CssConfigurator.java
+++ b/projects/copper-monitoring/copper-monitoring-client/src/main/java/org/copperengine/monitoring/client/ui/settings/CssConfigurator.java
@@ -46,8 +46,14 @@ public class CssConfigurator {
             themeColorsFile.deleteOnExit();
 
             String colorsCssContent = cssConfig.getColorsCssContent();
-            try (Writer cssWriter = new FileWriter(themeColorsFile)) {
+            Writer cssWriter = null;
+            try {
+                cssWriter = new FileWriter(themeColorsFile);
                 cssWriter.write(colorsCssContent);
+            } finally {
+                if(cssWriter != null) {
+                    cssWriter.close();
+                }
             }
             stylesheets.add(themeColorsFile.toURI().toURL().toExternalForm());
         }


### PR DESCRIPTION
copper-monitoring-client is in release 3.1.0 no longer java 6 compatible.
