### PR TITLE
Added support for OSGi metadata in build artefacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ configure(subprojects.findAll {
     println "configuring java module " + project.path
 
     apply plugin: 'java'
+    apply plugin: 'osgi'
     compileJava.options.encoding = 'utf-8'
     compileJava.sourceCompatibility = JavaVersion.VERSION_1_6
     compileJava.targetCompatibility = JavaVersion.VERSION_1_6


### PR DESCRIPTION
Applying the OSGi plugin adds metadata to the generated JAR build artefact. An example manifest is as follows:

```
Manifest-Version: 1.0
Export-Package: org.copperengine.core;version="3.2.2.SNAPSHOT";uses:="
 org.copperengine.core.persistent",org.copperengine.core.audit;version
 ="3.2.2.SNAPSHOT";uses:="javax.sql,org.copperengine.core.batcher,org.
 copperengine.management",org.copperengine.core.batcher;version="3.2.2
 .SNAPSHOT";uses:="javax.sql,org.copperengine.core",org.copperengine.c
 ore.batcher.impl;version="3.2.2.SNAPSHOT";uses:="org.copperengine.cor
 e.batcher,org.copperengine.core.monitoring,org.copperengine.managemen
 t",org.copperengine.core.common;version="3.2.2.SNAPSHOT";uses:="javax
 .management,org.copperengine.core,org.copperengine.core.instrument,or
 g.copperengine.core.internal,org.copperengine.core.monitoring,org.cop
 perengine.core.util,org.copperengine.management,org.copperengine.mana
 gement.model,org.slf4j",org.copperengine.core.db.utility;version="3.2
 .2.SNAPSHOT";uses:="javax.sql",org.copperengine.core.db.utility.oracl
 e;version="3.2.2.SNAPSHOT";uses:="org.copperengine.core.db.utility",o
 rg.copperengine.core.instrument;version="3.2.2.SNAPSHOT";uses:="org.o
 bjectweb.asm,org.objectweb.asm.tree",org.copperengine.core.internal;v
 ersion="3.2.2.SNAPSHOT";uses:="org.copperengine.core",org.copperengin
 e.core.monitoring;version="3.2.2.SNAPSHOT";uses:="org.copperengine.ma
 nagement,org.copperengine.management.model",org.copperengine.core.per
 sistent;version="3.2.2.SNAPSHOT";uses:="javax.sql,org.copperengine.co
 re,org.copperengine.core.batcher,org.copperengine.core.common,org.cop
 perengine.core.monitoring,org.copperengine.core.persistent.txn,org.co
 pperengine.management,org.copperengine.management.model",org.copperen
 gine.core.persistent.adapter;version="3.2.2.SNAPSHOT";uses:="org.copp
 erengine.core.batcher,org.copperengine.core.persistent,org.copperengi
 ne.core.persistent.txn",org.copperengine.core.persistent.alpha.genera
 tor;version="3.2.2.SNAPSHOT";uses:="org.copperengine.core.persistent"
 ,org.copperengine.core.persistent.lock;version="3.2.2.SNAPSHOT";uses:
 ="org.copperengine.core,org.copperengine.core.persistent.txn",org.cop
 perengine.core.persistent.txn;version="3.2.2.SNAPSHOT";uses:="javax.s
 ql",org.copperengine.core.tranzient;version="3.2.2.SNAPSHOT";uses:="o
 rg.copperengine.core,org.copperengine.core.common,org.copperengine.co
 re.monitoring,org.copperengine.management,org.copperengine.management
 .model",org.copperengine.core.util;version="3.2.2.SNAPSHOT";uses:="ja
 vax.sql,org.copperengine.core,org.copperengine.core.persistent.txn",o
 rg.copperengine.core.wfrepo;version="3.2.2.SNAPSHOT";uses:="org.coppe
 rengine.core,org.copperengine.core.instrument,org.copperengine.manage
 ment,org.copperengine.management.model"
Bundle-Version: 3.2.2.SNAPSHOT
Tool: Bnd-2.1.0.20130426-122213
Bundle-Name: copper-coreengine
Bnd-LastModified: 1442928724000
Created-By: 1.7.0_45 (Oracle Corporation)
Bundle-ManifestVersion: 2
Bundle-SymbolicName: org.copper-engine.copper-coreengine
Import-Package: javax.management,javax.sql,javax.tools,javax.xml.bind,
 org.copperengine.management;version="[3.2,4)",org.copperengine.manage
 ment.model;version="[3.2,4)",org.objectweb.asm;version="[5.0,6)",org.
 objectweb.asm.tree;version="[5.0,6)",org.objectweb.asm.util;version="
 [5.0,6)",org.slf4j;version="[1.7,2)"
provider: gradle
```