### PR TITLE
add queryAllActiveWorkflowInstance to processEngineMXBean

### DIFF
--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/common/AbstractProcessingEngine.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/common/AbstractProcessingEngine.java
@@ -79,6 +79,7 @@ public abstract class AbstractProcessingEngine implements ProcessingEngine, Proc
         return (dependencyInjector != null) ? dependencyInjector.getType() : "UNKNOWN";
     }
 
+    @Override
     public EngineState getEngineState() {
         return engineState;
     }
@@ -87,6 +88,7 @@ public abstract class AbstractProcessingEngine implements ProcessingEngine, Proc
         this.engineIdProvider = engineIdProvider;
     }
 
+    @Override
     public String getEngineId() {
         return engineIdProvider.getEngineId();
     }
@@ -118,6 +120,7 @@ public abstract class AbstractProcessingEngine implements ProcessingEngine, Proc
         return wfRepository.createWorkflowFactory(classname);
     }
 
+    @Override
     public synchronized void addShutdownObserver(Runnable observer) {
         shutdownObserver.add(observer);
     }
@@ -148,7 +151,9 @@ public abstract class AbstractProcessingEngine implements ProcessingEngine, Proc
         wfi.setId(wf.getId());
         wfi.setPriority(wf.getPriority());
         wfi.setProcessorPoolId(wf.getProcessorPoolId());
-        wfi.setState(wf.getProcessingState().name());
+        if (wf.getProcessingState() != null) {
+            wfi.setState(wf.getProcessingState().name());
+        }
         wfi.setTimeout(null); // TODO
         return wfi;
     }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
@@ -35,6 +35,7 @@ import java.util.Map;
 
 import org.copperengine.core.Acknowledge;
 import org.copperengine.core.DuplicateIdException;
+import org.copperengine.core.ProcessingState;
 import org.copperengine.core.Response;
 import org.copperengine.core.Workflow;
 import org.copperengine.core.batcher.BatchCommand;
@@ -76,15 +77,18 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
 
     }
 
+    @Override
     public void startup() {
         initStats();
     }
 
+    @Override
     public void setDbBatchingLatencyMSec(int dbBatchingLatencyMSec) {
         logger.info("setDbBatchingLatencyMSec({})", dbBatchingLatencyMSec);
         this.dbBatchingLatencyMSec = dbBatchingLatencyMSec;
     }
 
+    @Override
     public int getDbBatchingLatencyMSec() {
         return dbBatchingLatencyMSec;
     }
@@ -96,11 +100,13 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
      * @param defaultStaleResponseRemovalTimeout
      *        removal timeout
      */
+    @Override
     public void setDefaultStaleResponseRemovalTimeout(long defaultStaleResponseRemovalTimeout) {
         logger.info("setDefaultStaleResponseRemovalTimeout({})", defaultStaleResponseRemovalTimeout);
         this.defaultStaleResponseRemovalTimeout = defaultStaleResponseRemovalTimeout;
     }
 
+    @Override
     public long getDefaultStaleResponseRemovalTimeout() {
         return defaultStaleResponseRemovalTimeout;
     }
@@ -267,7 +273,7 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
                         PersistentWorkflow<?> wf = (PersistentWorkflow<?>) map.get(bpId);
                         Response<?> r = null;
                         if (response != null) {
-                            r = (Response<?>) serializer.deserializeResponse(response);
+                            r = serializer.deserializeResponse(response);
                             wf.addResponseId(r.getResponseId());
                         } else if (isTimeout) {
                             // timeout
@@ -286,7 +292,7 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
                 queueDeleteStmtStatistic.stop(map.size());
 
                 @SuppressWarnings("unchecked")
-                Collection<PersistentWorkflow<?>> workflows = (Collection<PersistentWorkflow<?>>) (Collection) map.values();
+                Collection<PersistentWorkflow<?>> workflows = (Collection) map.values();
                 workflowPersistencePlugin.onWorkflowsLoaded(con, workflows);
                 rv.addAll(workflows);
             }
@@ -403,7 +409,28 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
 
     @Override
     public void restartAll(Connection c) throws Exception {
-        throw new UnsupportedOperationException();
+        PreparedStatement insertStmt = null;
+        PreparedStatement stmtInstance = null;
+        try {
+            insertStmt = c.prepareStatement("insert into COP_QUEUE (ppool_id, priority, last_mod_ts, WORKFLOW_INSTANCE_ID) (select ppool_id, priority, last_mod_ts, id from COP_WORKFLOW_INSTANCE where state=? or state=?)");
+            insertStmt.setInt(1, DBProcessingState.ERROR.ordinal());
+            insertStmt.setInt(2, DBProcessingState.INVALID.ordinal());
+            logger.info("Adding all BPs in state INVALID & ERROR to queue...");
+            int rowCount = insertStmt.executeUpdate();
+            if (rowCount > 0) {
+                final Timestamp NOW = new Timestamp(System.currentTimeMillis());
+                stmtInstance = c.prepareStatement("UPDATE COP_WORKFLOW_INSTANCE SET STATE=?, LAST_MOD_TS=? WHERE STATE=? OR STATE=?");
+                stmtInstance.setInt(1, DBProcessingState.ENQUEUED.ordinal());
+                stmtInstance.setTimestamp(2, NOW);
+                stmtInstance.setInt(3, DBProcessingState.ERROR.ordinal());
+                stmtInstance.setInt(4, DBProcessingState.INVALID.ordinal());
+                stmtInstance.execute();
+            }
+            logger.info("done - restartAll invalid: " + rowCount + " BP(s).");
+        } finally {
+            JdbcUtils.closeStatement(stmtInstance);
+            JdbcUtils.closeStatement(insertStmt);
+        }
     }
 
     @Override
@@ -644,7 +671,7 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
                 String response = rsResponses.getString(4);
                 Response<?> r = null;
                 if (response != null) {
-                    r = (Response<?>) serializer.deserializeResponse(response);
+                    r = serializer.deserializeResponse(response);
                     wf.addResponseId(r.getResponseId());
                 } else if (isTimeout) {
                     // timeout
@@ -670,4 +697,40 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
         return dequeueStmt;
     }
 
+    @Override
+    public List<Workflow<?>> queryAllActive(final String className, Connection c) throws SQLException {
+        final PreparedStatement queryStmt;
+        if (className != null) {
+            queryStmt = c.prepareStatement("select id,state,priority,ppool_id,data,object_state,creation_ts from COP_WORKFLOW_INSTANCE where state in (0,1,2) and classname=?");
+            queryStmt.setString(1, className);
+        } else {
+            queryStmt = c.prepareStatement("select id,state,priority,ppool_id,data,object_state,creation_ts from COP_WORKFLOW_INSTANCE where state in (0,1,2)");
+        }
+        final ResultSet rs = queryStmt.executeQuery();
+        final List<Workflow<?>> result = new ArrayList<Workflow<?>>();
+        while (rs.next()) {
+            final String id = rs.getString(1);
+            final int prio = rs.getInt(3);
+            final String ppoolId = rs.getString(4);
+            try {
+                SerializedWorkflow sw = new SerializedWorkflow();
+                sw.setData(rs.getString(5));
+                sw.setObjectState(rs.getString(6));
+                PersistentWorkflow<?> wf = (PersistentWorkflow<?>) serializer.deserializeWorkflow(sw, wfRepository);
+                wf.setId(id);
+                wf.setProcessorPoolId(ppoolId);
+                wf.setPriority(prio);
+                DBProcessingState dbProcessingState = DBProcessingState.getByOrdinal(rs.getInt(2));
+                ProcessingState state = DBProcessingState.getProcessingStateByState(dbProcessingState);
+                WorkflowAccessor.setProcessingState(wf, state);
+                WorkflowAccessor.setCreationTS(wf, new Date(rs.getTimestamp(7).getTime()));
+                result.add(wf);
+            } catch (Exception e) {
+                logger.error("decoding of '" + id + "' failed: " + e.toString(), e);
+            }
+        }
+        rs.close();
+        queryStmt.close();
+        return result;
+    }
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DBProcessingState.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DBProcessingState.java
@@ -15,11 +15,43 @@
  */
 package org.copperengine.core.persistent;
 
+import org.copperengine.core.ProcessingState;
+
 public enum DBProcessingState {
     ENQUEUED,
     PROCESSING /* so far unused */,
     WAITING,
     FINISHED,
     INVALID,
-    ERROR
+    ERROR;
+
+    public static DBProcessingState getByOrdinal(int ordinal) {
+        return values()[ordinal];
+    }
+
+    public static ProcessingState getProcessingStateByState(DBProcessingState state){
+        ProcessingState processingState;
+        switch (state) {
+            case ENQUEUED:
+            case PROCESSING:
+                processingState = ProcessingState.RUNNING;
+                break;
+            case WAITING:
+                processingState = ProcessingState.WAITING;
+                break;
+            case FINISHED:
+                processingState = ProcessingState.FINISHED;
+                break;
+            case INVALID:
+                processingState = ProcessingState.INVALID;
+                break;
+            case ERROR:
+                processingState = ProcessingState.ERROR;
+                break;
+            default:
+                processingState = ProcessingState.RAW;
+        }
+        return processingState;
+    }
+
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DatabaseDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DatabaseDialect.java
@@ -79,4 +79,16 @@ public interface DatabaseDialect {
 
     public abstract Workflow<?> read(String workflowInstanceId, Connection con) throws Exception;
 
+    /**
+     * Query workflows that were active at the moment (in ENQUEU, RUNNING OR WAITING state)
+     * 
+     * @param className
+     *        - optional, specify which className it want to return
+     * @param con
+     *        - database connection
+     * @return
+     * @throws Exception
+     */
+    public List<Workflow<?>> queryAllActive(final String className, Connection con) throws SQLException;
+
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/OracleDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/OracleDialect.java
@@ -35,6 +35,7 @@ import org.copperengine.core.Acknowledge;
 import org.copperengine.core.CopperRuntimeException;
 import org.copperengine.core.DuplicateIdException;
 import org.copperengine.core.EngineIdProvider;
+import org.copperengine.core.ProcessingState;
 import org.copperengine.core.Response;
 import org.copperengine.core.Workflow;
 import org.copperengine.core.batcher.BatchCommand;
@@ -87,6 +88,7 @@ public class OracleDialect implements DatabaseDialect, DatabaseDialectMXBean {
         initStmtStats();
     }
 
+    @Override
     public void startup() {
         if (engineIdProvider == null || engineIdProvider.getEngineId() == null)
             throw new NullPointerException("EngineId is NULL! Change your " + getClass().getSimpleName() + " configuration.");
@@ -104,6 +106,7 @@ public class OracleDialect implements DatabaseDialect, DatabaseDialectMXBean {
 
     }
 
+    @Override
     public void setDbBatchingLatencyMSec(int dbBatchingLatencyMSec) {
         this.dbBatchingLatencyMSec = dbBatchingLatencyMSec;
     }
@@ -116,10 +119,12 @@ public class OracleDialect implements DatabaseDialect, DatabaseDialectMXBean {
      * @param defaultStaleResponseRemovalTimeout
      *        timeout
      */
+    @Override
     public void setDefaultStaleResponseRemovalTimeout(long defaultStaleResponseRemovalTimeout) {
         this.defaultStaleResponseRemovalTimeout = defaultStaleResponseRemovalTimeout;
     }
 
+    @Override
     public void setRemoveWhenFinished(boolean removeWhenFinished) {
         this.removeWhenFinished = removeWhenFinished;
     }
@@ -152,6 +157,7 @@ public class OracleDialect implements DatabaseDialect, DatabaseDialectMXBean {
         return runtimeStatisticsCollector;
     }
 
+    @Override
     public boolean isRemoveWhenFinished() {
         return removeWhenFinished;
     }
@@ -160,6 +166,7 @@ public class OracleDialect implements DatabaseDialect, DatabaseDialectMXBean {
         return serializer;
     }
 
+    @Override
     public long getDefaultStaleResponseRemovalTimeout() {
         return defaultStaleResponseRemovalTimeout;
     }
@@ -241,7 +248,7 @@ public class OracleDialect implements DatabaseDialect, DatabaseDialectMXBean {
         dequeueWait4RespLdrStmtStatistic.stop(map.size());
 
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        Collection<PersistentWorkflow<?>> workflows = (Collection<PersistentWorkflow<?>>) (Collection) map.values();
+        Collection<PersistentWorkflow<?>> workflows = (Collection) map.values();
         workflowPersistencePlugin.onWorkflowsLoaded(con, workflows);
         rv.addAll(workflows);
 
@@ -520,6 +527,7 @@ public class OracleDialect implements DatabaseDialect, DatabaseDialectMXBean {
         cmd.executor().doExec(commands, con);
     }
 
+    @Override
     public List<String> checkDbConsistency(Connection con) throws Exception {
         if (multiEngineMode)
             throw new CopperRuntimeException("Cannot check DB consistency when multiEngineMode is turned on!");
@@ -560,6 +568,7 @@ public class OracleDialect implements DatabaseDialect, DatabaseDialectMXBean {
         }
     }
 
+    @Override
     public void shutdown() {
         synchronized (responseLoaders) {
             for (ResponseLoader responseLoader : responseLoaders.values()) {
@@ -638,7 +647,7 @@ public class OracleDialect implements DatabaseDialect, DatabaseDialectMXBean {
                     response = rsResponses.getString(4);
                 Response<?> r = null;
                 if (response != null) {
-                    r = (Response<?>) serializer.deserializeResponse(response);
+                    r = serializer.deserializeResponse(response);
                     wf.addResponseId(r.getResponseId());
                 } else if (isTimeout) {
                     r = new Response<Object>(cid);
@@ -661,6 +670,43 @@ public class OracleDialect implements DatabaseDialect, DatabaseDialectMXBean {
         PreparedStatement dequeueStmt = c.prepareStatement("select id,priority,data,object_state,creation_ts,PPOOL_ID from COP_WORKFLOW_INSTANCE where id = ?");
         dequeueStmt.setString(1, workflowId);
         return dequeueStmt;
+    }
+
+    @Override
+    public List<Workflow<?>> queryAllActive(final String className, Connection c) throws SQLException {
+        final PreparedStatement queryStmt;
+        if (className != null) {
+            queryStmt = c.prepareStatement("select id,state,priority,ppool_id,data,object_state,creation_ts from COP_WORKFLOW_INSTANCE where state in (0,1,2) and classname=?");
+            queryStmt.setString(1, className);
+        } else {
+            queryStmt = c.prepareStatement("select id,state,priority,ppool_id,data,object_state,creation_ts from COP_WORKFLOW_INSTANCE where state in (0,1,2)");
+        }
+        final ResultSet rs = queryStmt.executeQuery();
+        final List<Workflow<?>> result = new ArrayList<Workflow<?>>();
+        while (rs.next()) {
+            final String id = rs.getString(1);
+            final int prio = rs.getInt(3);
+            final String ppoolId = rs.getString(4);
+            try {
+                SerializedWorkflow sw = new SerializedWorkflow();
+                sw.setData(rs.getString(5));
+                sw.setObjectState(rs.getString(6));
+                PersistentWorkflow<?> wf = (PersistentWorkflow<?>) serializer.deserializeWorkflow(sw, wfRepository);
+                wf.setId(id);
+                wf.setProcessorPoolId(ppoolId);
+                wf.setPriority(prio);
+                DBProcessingState dbProcessingState = DBProcessingState.getByOrdinal(rs.getInt(2));
+                ProcessingState state = DBProcessingState.getProcessingStateByState(dbProcessingState);
+                WorkflowAccessor.setProcessingState(wf, state);
+                WorkflowAccessor.setCreationTS(wf, new Date(rs.getTimestamp(7).getTime()));
+                result.add(wf);
+            } catch (Exception e) {
+                logger.error("decoding of '" + id + "' failed: " + e.toString(), e);
+            }
+        }
+        rs.close();
+        queryStmt.close();
+        return result;
     }
 
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentScottyEngine.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentScottyEngine.java
@@ -316,6 +316,7 @@ public class PersistentScottyEngine extends AbstractProcessingEngine implements 
         getAndRemoveWaitHooks(wf); // Clean up...
     }
 
+    @Override
     public int getNumberOfWorkflowInstances() {
         return workflowMap.size();
     }
@@ -424,6 +425,22 @@ public class PersistentScottyEngine extends AbstractProcessingEngine implements 
     @Override
     public DBStorageMXBean getDBStorage() {
         return (DBStorageMXBean) (dbStorage instanceof DBStorageMXBean ? dbStorage : null);
+    }
+
+    @Override
+    public List<WorkflowInfo> queryActiveWorkflowInstances(String className) {
+        List<WorkflowInfo> rv = new ArrayList<WorkflowInfo>();
+        try {
+            List<Workflow<?>> wfs = dbStorage.queryAllActive(className);
+            for (Workflow<?> wf : wfs) {
+                WorkflowInfo wfi = convert2Wfi(wf);
+                rv.add(wfi);
+            }
+        } catch (Exception e) {
+            logger.error("queryWorkflowInstances failed: " + e.getMessage(), e);
+        }
+        logger.info("queryWorkflowInstances returned " + rv.size() + " instance(s)");
+        return rv;
     }
 
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PostgreSQLDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PostgreSQLDialect.java
@@ -34,6 +34,7 @@ import org.copperengine.core.batcher.BatchCommand;
  */
 public class PostgreSQLDialect extends AbstractSqlDialect {
 
+    @Override
     protected PreparedStatement createUpdateStateStmt(final Connection c, final int max) throws SQLException {
         final Timestamp NOW = new Timestamp(System.currentTimeMillis());
         PreparedStatement pstmt = c.prepareStatement(queryUpdateQueueState + " LIMIT " + max);
@@ -42,12 +43,14 @@ public class PostgreSQLDialect extends AbstractSqlDialect {
         return pstmt;
     }
 
+    @Override
     protected PreparedStatement createDequeueStmt(final Connection c, final String ppoolId, final int max) throws SQLException {
         PreparedStatement dequeueStmt = c.prepareStatement("select id,priority,data,object_state,creation_ts from COP_WORKFLOW_INSTANCE where id in (select WORKFLOW_INSTANCE_ID from COP_QUEUE where ppool_id = ? order by priority, last_mod_ts) LIMIT " + max);
         dequeueStmt.setString(1, ppoolId);
         return dequeueStmt;
     }
 
+    @Override
     protected PreparedStatement createDeleteStaleResponsesStmt(final Connection c, final int MAX_ROWS) throws SQLException {
         PreparedStatement stmt = c.prepareStatement("delete from COP_RESPONSE where response_timeout < ? and not exists (select * from COP_WAIT w where w.correlation_id = COP_RESPONSE.correlation_id LIMIT " + MAX_ROWS + ")");
         stmt.setTimestamp(1, new Timestamp(System.currentTimeMillis()));

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/ScottyDBStorage.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/ScottyDBStorage.java
@@ -99,6 +99,7 @@ public class ScottyDBStorage implements ScottyDBStorageInterface, ScottyDBStorag
         });
     }
 
+    @Override
     public void insert(final Workflow<?> wf, final Acknowledge ack) throws Exception {
         logger.trace("insert({})", wf);
         try {
@@ -116,6 +117,7 @@ public class ScottyDBStorage implements ScottyDBStorageInterface, ScottyDBStorag
         }
     }
 
+    @Override
     public void insert(final List<Workflow<?>> wfs, final Acknowledge ack) throws Exception {
         logger.trace("insert(wfs.size={})", wfs.size());
         try {
@@ -200,11 +202,13 @@ public class ScottyDBStorage implements ScottyDBStorageInterface, ScottyDBStorag
         return r;
     }
 
+    @Override
     public void notify(final List<Response<?>> response, Acknowledge ack) throws Exception {
         for (Response<?> r : response)
             notify(r, ack);
     }
 
+    @Override
     public synchronized void startup() {
         try {
             dialect.startup();
@@ -276,6 +280,7 @@ public class ScottyDBStorage implements ScottyDBStorageInterface, ScottyDBStorag
         } while (n == MAX_ROWS);
     }
 
+    @Override
     public synchronized void shutdown() {
         if (shutdown)
             return;
@@ -354,6 +359,7 @@ public class ScottyDBStorage implements ScottyDBStorageInterface, ScottyDBStorag
             dialect.insert(wfs, con);
     }
 
+    @Override
     public void restart(final String workflowInstanceId) throws Exception {
         run(new DatabaseTransaction<Void>() {
             @Override
@@ -422,6 +428,7 @@ public class ScottyDBStorage implements ScottyDBStorageInterface, ScottyDBStorag
         }
     }
 
+    @Override
     public void registerCallback(final RegisterCall rc, final Acknowledge callback) throws Exception {
         if (logger.isTraceEnabled())
             logger.trace("registerCallback(" + rc + ")");
@@ -430,6 +437,7 @@ public class ScottyDBStorage implements ScottyDBStorageInterface, ScottyDBStorag
         executeBatchCommand(dialect.createBatchCommand4registerCallback(rc, this, callback));
     }
 
+    @Override
     public void notify(final Response<?> response, final Acknowledge callback) throws Exception {
         if (logger.isTraceEnabled())
             logger.trace("notify(" + response + ")");
@@ -450,6 +458,7 @@ public class ScottyDBStorage implements ScottyDBStorageInterface, ScottyDBStorag
         executeBatchCommand(dialect.createBatchCommand4Notify(response, notify));
     }
 
+    @Override
     public void finish(final Workflow<?> w, final Acknowledge callback) {
         if (logger.isTraceEnabled())
             logger.trace("finish(" + w.getId() + ")");
@@ -482,6 +491,16 @@ public class ScottyDBStorage implements ScottyDBStorageInterface, ScottyDBStorag
             @Override
             public Workflow<?> run(Connection con) throws Exception {
                 return dialect.read(workflowInstanceId, con);
+            }
+        });
+    }
+
+    @Override
+    public List<Workflow<?>> queryAllActive(final String className) throws Exception {
+        return run(new DatabaseTransaction<List<Workflow<?>>>() {
+            @Override
+            public List<Workflow<?>> run(Connection con) throws Exception {
+                return dialect.queryAllActive(className, con);
             }
         });
     }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/ScottyDBStorageInterface.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/ScottyDBStorageInterface.java
@@ -133,4 +133,15 @@ public interface ScottyDBStorageInterface {
      */
     public Workflow<?> read(final String workflowInstanceId) throws Exception;
 
+    /**
+     * Query all active workflowinstances from the backing storage
+     * 
+     * @param className
+     *        optional - className of the active workflow instances
+     * @return list of deserialized workflow instance
+     * @throws Exception
+     */
+    public List<Workflow<?>> queryAllActive(final String className) throws Exception;
+
+
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/tranzient/TransientScottyEngine.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/tranzient/TransientScottyEngine.java
@@ -67,6 +67,7 @@ public class TransientScottyEngine extends AbstractProcessingEngine implements P
     private TicketPoolManager ticketPoolManager;
     private RuntimeStatisticsCollector statisticsCollector = new NullRuntimeStatisticsCollector();
 
+    @Override
     public void setStatisticsCollector(RuntimeStatisticsCollector statisticsCollector) {
         this.statisticsCollector = statisticsCollector;
     }
@@ -310,6 +311,7 @@ public class TransientScottyEngine extends AbstractProcessingEngine implements P
         return convert2Wfi(workflowMap.get(id));
     }
 
+    @Override
     public int getNumberOfWorkflowInstances() {
         return workflowMap.size();
     }
@@ -333,6 +335,18 @@ public class TransientScottyEngine extends AbstractProcessingEngine implements P
     @Override
     public EngineType getEngineType() {
         return EngineType.tranzient;
+    }
+
+    @Override
+    public List<WorkflowInfo> queryActiveWorkflowInstances(String className) {
+        List<WorkflowInfo> rv = new ArrayList<WorkflowInfo>();
+        for (Workflow<?> wf : workflowMap.values()) {
+            WorkflowInfo wfi = convert2Wfi(wf);
+            if (wfi.getWorkflowClassInfo() != null && wfi.getWorkflowClassInfo().getClassname().equals(className)) {
+                rv.add(wfi);
+            }
+        }
+        return rv;
     }
 
 }

--- a/projects/copper-jmx-interface/src/main/java/org/copperengine/management/ProcessingEngineMXBean.java
+++ b/projects/copper-jmx-interface/src/main/java/org/copperengine/management/ProcessingEngineMXBean.java
@@ -29,6 +29,8 @@ public interface ProcessingEngineMXBean {
 
     public List<WorkflowInfo> queryWorkflowInstances();
 
+    public List<WorkflowInfo> queryActiveWorkflowInstances(String className);
+
     public WorkflowInfo queryWorkflowInstance(String id);
 
     public int getNumberOfWorkflowInstances();


### PR DESCRIPTION
- implement restartAll() for all sql storages, wonder why it throws Unimplement for all other than Oracle
- add queryAllActiveWorkflowInstance(<Optional> String className) to return all ENQUEUED, PROCESSING and WAITING flows

note... somehow AbstractSqlDialect.java shows a lot of modification.. but I only modified a few... could be my merge tool problem...