### PR TITLE
- add queryActiveWorkflowInstance(String id) to get workflow 

### DIFF
--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
@@ -256,7 +256,7 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
             dequeueStmtStatistic.stop(map.size());
 
             if (!map.isEmpty()) {
-                selectResponsesStmt = con.prepareStatement("select w.WORKFLOW_INSTANCE_ID, w.correlation_id, w.timeout_ts, r.response from (select WORKFLOW_INSTANCE_ID, correlation_id, timeout_ts from COP_WAIT where WORKFLOW_INSTANCE_ID in (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)) w LEFT OUTER JOIN COP_RESPONSE r ON w.correlation_id = r.correlation_id");
+                selectResponsesStmt = con.prepareStatement("select w.WORKFLOW_INSTANCE_ID, w.correlation_id, w.timeout_ts, r.response from (select WORKFLOW_INSTANCE_ID, correlation_id, timeout_ts from COP_WAIT where WORKFLOW_INSTANCE_ID in (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)) w LEFT OUTER JOIN COP_RESPONSE r ON w.correlation_id = r.correlation_id order by r.RESPONSE_TS");
                 List<List<String>> ids = splitt(map.keySet(), 25);
                 for (List<String> id : ids) {
                     selectResponsesStmt.clearParameters();

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
@@ -658,6 +658,9 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
             wf.setPriority(prio);
             wf.setProcessorPoolId(rs.getString(6));
             WorkflowAccessor.setCreationTS(wf, new Date(rs.getTimestamp(5).getTime()));
+            DBProcessingState dbProcessingState = DBProcessingState.getByOrdinal(rs.getInt(7));
+            ProcessingState state = DBProcessingState.getProcessingStateByState(dbProcessingState);
+            WorkflowAccessor.setProcessingState(wf, state);
             rs.close();
             readStmt.close();
 
@@ -692,7 +695,7 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
     }
 
     protected PreparedStatement createReadStmt(final Connection c, final String workflowId) throws SQLException {
-        PreparedStatement dequeueStmt = c.prepareStatement("select id,priority,data,object_state,creation_ts,PPOOL_ID from COP_WORKFLOW_INSTANCE where id = ?");
+        PreparedStatement dequeueStmt = c.prepareStatement("select id,priority,data,object_state,creation_ts,PPOOL_ID,state from COP_WORKFLOW_INSTANCE where id = ?");
         dequeueStmt.setString(1, workflowId);
         return dequeueStmt;
     }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/OracleDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/OracleDialect.java
@@ -603,7 +603,7 @@ public class OracleDialect implements DatabaseDialect, DatabaseDialectMXBean {
         PreparedStatement readStmt = null;
         PreparedStatement selectResponsesStmt = null;
         try {
-            readStmt = con.prepareStatement("select id,priority,data,rowid,long_data,creation_ts,object_state,long_object_state,ppool_id from COP_WORKFLOW_INSTANCE where id = ?");
+            readStmt = con.prepareStatement("select id,priority,data,rowid,long_data,creation_ts,object_state,long_object_state,ppool_id,state from COP_WORKFLOW_INSTANCE where id = ?");
             readStmt.setString(1, workflowInstanceId);
 
             final ResultSet rs = readStmt.executeQuery();
@@ -633,6 +633,10 @@ public class OracleDialect implements DatabaseDialect, DatabaseDialectMXBean {
             wf.oldPrio = prio;
             wf.oldProcessorPoolId = rs.getString(9);
             WorkflowAccessor.setCreationTS(wf, new Date(creationTS.getTime()));
+            DBProcessingState dbProcessingState = DBProcessingState.getByOrdinal(rs.getInt(10));
+            ProcessingState state = DBProcessingState.getProcessingStateByState(dbProcessingState);
+            WorkflowAccessor.setProcessingState(wf, state);
+
             rs.close();
             readStmt.close();
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentScottyEngine.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentScottyEngine.java
@@ -443,4 +443,20 @@ public class PersistentScottyEngine extends AbstractProcessingEngine implements 
         return rv;
     }
 
+    @Override
+    public WorkflowInfo queryActiveWorkflowInstance(final String id) {
+        // first, get from map
+        WorkflowInfo wfi = convert2Wfi(workflowMap.get(id));
+        if (wfi == null) {
+            // try get from db
+            try {
+                Workflow<?> wf = dbStorage.read(id);
+                wfi = convert2Wfi(wf);
+            } catch (Exception e) {
+                logger.error("queryActiveWorkflowInstance failed: id=" + id + ", " + e.getMessage(), e);
+            }
+        }
+        return wfi;
+    }
+
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/tranzient/TransientScottyEngine.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/tranzient/TransientScottyEngine.java
@@ -351,4 +351,10 @@ public class TransientScottyEngine extends AbstractProcessingEngine implements P
         return rv;
     }
 
+    @Override
+    public WorkflowInfo queryActiveWorkflowInstance(final String id) {
+        // Same as this one for transient engine
+        return queryWorkflowInstance(id);
+    }
+
 }

--- a/projects/copper-jmx-interface/src/main/java/org/copperengine/management/ProcessingEngineMXBean.java
+++ b/projects/copper-jmx-interface/src/main/java/org/copperengine/management/ProcessingEngineMXBean.java
@@ -27,11 +27,36 @@ public interface ProcessingEngineMXBean {
 
     public EngineType getEngineType();
 
+    /**
+     * Query all <b>currently Running</b> instances from memory only, <b>Note it WON'T return instances in WAITING
+     * state</b>
+     * 
+     */
     public List<WorkflowInfo> queryWorkflowInstances();
 
+    /**
+     * Query all active instances, this includes instances in ENQUEUED, WAITING and RUNNING state
+     * 
+     * @param className
+     *        - optional, returns workflow instances
+     * @param max
+     *        - to limit of number of workflows returned
+     */
     public List<WorkflowInfo> queryActiveWorkflowInstances(String className, int max);
 
+    /**
+     * query one workflow instance from memory, <b>Note it WON'T return instances in WAITING state</b>
+     * 
+     * @param id
+     */
     public WorkflowInfo queryWorkflowInstance(String id);
+
+    /**
+     * query one workflow instance from memory or db regardless of its state
+     * 
+     * @param id
+     */
+    public WorkflowInfo queryActiveWorkflowInstance(String id);
 
     public int getNumberOfWorkflowInstances();
 


### PR DESCRIPTION
- add queryActiveWorkflowInstance(String id) to get workflow from memory or db
- add state to dbStorage.read() because it's missing
- add descriptions to  queryWorkflowInstance(), queryActiveWorkflowInstance()  so user could differentiate