### PR TITLE
Add multiEngineMode to AbstractSqlDialet, default to true. Implemented lock for MySQL and PostgreSQL Dialet

### DIFF
--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/Workflow.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/Workflow.java
@@ -176,7 +176,7 @@ public abstract class Workflow<D> implements Serializable {
      * @param mode
      *        WaitMode
      * @param timeoutMsec
-     *        timeout in milliseconds or {@link Workflow#NO_TIMEOUT} (or any value <= 0) to wait for ever
+     *        timeout in milliseconds or {@link Workflow#NO_TIMEOUT} (or any value &lt;= 0) to wait for ever
      * @param correlationIds
      *        one ore more correlation ids
      */
@@ -206,7 +206,7 @@ public abstract class Workflow<D> implements Serializable {
      * @param mode
      *        WaitMode
      * @param timeout
-     *        timeout or {@link Workflow#NO_TIMEOUT} (or any value <= 0) to wait for ever
+     *        timeout or {@link Workflow#NO_TIMEOUT} (or any value &lt;= 0) to wait for ever
      * @param timeUnit
      *        unit of the timeout; ignored, if a negative timeout is specified
      * @param correlationIds
@@ -230,7 +230,7 @@ public abstract class Workflow<D> implements Serializable {
      * @param mode
      *        WaitMode
      * @param timeout
-     *        timeout or {@link Workflow#NO_TIMEOUT} (or any value <= 0) to wait for ever
+     *        timeout or {@link Workflow#NO_TIMEOUT} (or any value &lt;= 0) to wait for ever
      * @param timeUnit
      *        unit of the timeout; ignored, if a negative timeout is specified
      * @param callbacks

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/common/AbstractJmxExporter.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/common/AbstractJmxExporter.java
@@ -71,28 +71,28 @@ public abstract class AbstractJmxExporter {
         }
     }
 
-    /** return a map with entries { "name" -> WorkflowRepositoryMXBean }. The map may be empty. */
+    /** return a map with entries { "name" -&gt; WorkflowRepositoryMXBean }. The map may be empty. */
     protected abstract Map<String, WorkflowRepositoryMXBean> getWorkflowRepositoryMXBeans();
 
-    /** return a map with entries { "name" -> ProcessingEngineMXBean }. The map may be empty. */
+    /** return a map with entries { "name" -&gt; ProcessingEngineMXBean }. The map may be empty. */
     protected abstract Map<String, ProcessingEngineMXBean> getProcessingEngineMXBeans();
 
-    /** return a map with entries { "name" -> ProcessorPoolMXBean }. The map may be empty. */
+    /** return a map with entries { "name" -&gt; ProcessorPoolMXBean }. The map may be empty. */
     protected abstract Map<String, ProcessorPoolMXBean> getProcessorPoolMXBeans();
 
-    /** return a map with entries { "name" -> StatisticsCollectorMXBean }. The map may be empty. */
+    /** return a map with entries { "name" -&gt; StatisticsCollectorMXBean }. The map may be empty. */
     protected abstract Map<String, StatisticsCollectorMXBean> getStatisticsCollectorMXBeans();
 
-    /** return a map with entries { "name" -> AuditTrailMXBean }. The map may be empty. */
+    /** return a map with entries { "name" -&gt; AuditTrailMXBean }. The map may be empty. */
     protected abstract Map<String, AuditTrailMXBean> getAuditTrailMXBeans();
 
-    /** return a map with entries { "name" -> BatcherMXBean }. The map may be empty. */
+    /** return a map with entries { "name" -&gt; BatcherMXBean }. The map may be empty. */
     protected abstract Map<String, BatcherMXBean> getBatcherMXBeans();
 
-    /** return a map with entries { "name" -> DatabaseDialectMXBean }. The map may be empty. */
+    /** return a map with entries { "name" -&gt; DatabaseDialectMXBean }. The map may be empty. */
     protected abstract Map<String, DatabaseDialectMXBean> getDatabaseDialectMXBeans();
 
-    /** return a map with entries { "name" -> AuditTrailQueryMXBean }. The map may be empty. */
+    /** return a map with entries { "name" -&gt; AuditTrailQueryMXBean }. The map may be empty. */
     protected abstract Map<String, AuditTrailQueryMXBean> getAuditTrailQueryMXBeans();
 
     private void register(MBeanServer mBeanServer, Map<String, ?> map, String domain) throws MalformedObjectNameException, InstanceAlreadyExistsException, MBeanRegistrationException, NotCompliantMBeanException {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/common/PriorityProcessorPool.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/common/PriorityProcessorPool.java
@@ -80,10 +80,10 @@ public abstract class PriorityProcessorPool implements ProcessorPool, ProcessorP
 
     /**
      * This processor pool wait up to the specified number of milliseconds until all of its Processors are terminated.
-     * A value <= 0 means, that the processor pool will not wait at all.
+     * A value &lt;= 0 means, that the processor pool will not wait at all.
      * 
      * @param shutdownWaitIntervalMSec
-     *            wait interval in milliseconds
+     *        wait interval in milliseconds
      */
     public void setShutdownWaitIntervalMSec(int shutdownWaitIntervalMSec) {
         this.shutdownWaitIntervalMSec = shutdownWaitIntervalMSec;
@@ -104,6 +104,7 @@ public abstract class PriorityProcessorPool implements ProcessorPool, ProcessorP
         this.id = id;
     }
 
+    @Override
     public synchronized void setNumberOfThreads(int numberOfThreads) {
         if (numberOfThreads <= 0 || numberOfThreads >= 2048)
             throw new IllegalArgumentException();
@@ -135,10 +136,12 @@ public abstract class PriorityProcessorPool implements ProcessorPool, ProcessorP
         }
     }
 
+    @Override
     public synchronized int getNumberOfThreads() {
         return numberOfThreads;
     }
 
+    @Override
     public synchronized void setThreadPriority(int threadPriority) {
         if (threadPriority != this.threadPriority) {
             logger.info("ProcessorPool " + id + ": Setting new thread priority to " + threadPriority);
@@ -149,6 +152,7 @@ public abstract class PriorityProcessorPool implements ProcessorPool, ProcessorP
         }
     }
 
+    @Override
     public synchronized int getThreadPriority() {
         return threadPriority;
     }
@@ -188,6 +192,7 @@ public abstract class PriorityProcessorPool implements ProcessorPool, ProcessorP
         }
     }
 
+    @Override
     public synchronized void startup() {
         if (id == null)
             throw new NullPointerException();

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/common/TicketPool.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/common/TicketPool.java
@@ -96,7 +96,7 @@ public class TicketPool {
      * are obtained.
      * 
      * @param count
-     *            number of tickets to obtain. must be 0 > count < maxTickets
+     *        number of tickets to obtain. must be 0 &gt; count &lt; maxTickets
      * @throws IllegalArgumentException
      */
     public void obtain(int count) throws IllegalArgumentException {
@@ -177,6 +177,7 @@ public class TicketPool {
         notifyAll();
     }
 
+    @Override
     public synchronized String toString() {
         return id + ": " + used + " of " + maxTickets + " tickets used";
     }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/db/utility/RetryingTransaction.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/db/utility/RetryingTransaction.java
@@ -79,15 +79,19 @@ public abstract class RetryingTransaction<R> implements Transaction<R> {
 
     /**
      * This function is to be implemented by anonymous inner classes. Usage
-     * should look like this: <code>...
+     * should look like this:
+     * 
+     * <pre>
+     * {@code
      * new RetryingTransaction<ReturnType>("TestTransaction") {
-     *       protected ReturnType execute() {
-     *             doSomething();
-     *             doAnotherThing();
-     *             return ...;
-     *       }
-     *    }.run();
-     *    </code>
+     * protected ReturnType execute() {
+     * doSomething();
+     * doAnotherThing();
+     * return ...;
+     * }
+     * }.run();
+     * }
+     * </pre>
      */
     protected abstract R execute() throws Exception;
 
@@ -100,6 +104,7 @@ public abstract class RetryingTransaction<R> implements Transaction<R> {
      * case of exceptions etc.), and automatic retries in case of deadlocks or
      * timeouts.
      */
+    @Override
     public final R run() throws Exception {
         if (getCurrent() != null) {
             if (logger.isDebugEnabled())

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
@@ -66,6 +66,7 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
      */
     protected boolean multiEngineMode = true;
     protected long defaultStaleResponseRemovalTimeout = 60 * 60 * 1000;
+    protected final int ACQUIRE_BLOCKING_WAIT_SEC = 10;
     protected Serializer serializer = new StandardJavaSerializer();
     protected int dbBatchingLatencyMSec = 20;
     private WorkflowPersistencePlugin workflowPersistencePlugin = WorkflowPersistencePlugin.NULL_PLUGIN;
@@ -129,6 +130,18 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
         enqueueUpdateStateStmtStatistic = new StmtStatistic("DBStorage.enqueue.updateState", runtimeStatisticsCollector);
         insertStmtStatistic = new StmtStatistic("DBStorage.insert", runtimeStatisticsCollector);
         deleteStaleResponsesStmtStatistic = new StmtStatistic("DBStorage.deleteStaleResponses", runtimeStatisticsCollector);
+    }
+
+    /**
+     * returns an int value between 0 and 1073741823 (exclusive)
+     */
+    protected static int computeLockId(String s) {
+        // This method handles the following fact: Math.abs(Integer.MIN_VALUE) == Integer.MIN_VALUE
+        int hashCode = s.hashCode();
+        if (hashCode == Integer.MIN_VALUE) {
+            hashCode = 13;
+        }
+        return Math.abs(hashCode) % 1073741823;
     }
 
     protected String getResourceAsString(String name) {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.copperengine.core.Acknowledge;
-import org.copperengine.core.CopperRuntimeException;
 import org.copperengine.core.DuplicateIdException;
 import org.copperengine.core.ProcessingState;
 import org.copperengine.core.Response;
@@ -619,8 +618,9 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
 
     @Override
     public List<String> checkDbConsistency(Connection con) throws Exception {
-        if (multiEngineMode)
-            throw new CopperRuntimeException("Cannot check DB consistency when multiEngineMode is turned on!");
+        if (multiEngineMode) {
+            logger.warn("Checking DB consistency when multiEngineMode is turned on!");
+        }
         final PreparedStatement dequeueStmt = con.prepareStatement("select id,priority,data,object_state,PPOOL_ID from COP_WORKFLOW_INSTANCE where state not in (?,?)");
         try {
             final List<String> idsOfBadWorkflows = new ArrayList<String>();

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
@@ -343,7 +343,7 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
         PreparedStatement queryStmt = null;
         PreparedStatement updStmt = null;
         PreparedStatement insStmt = null;
-        final String lockContext = "deleteStaleResponse";
+        final String lockContext = "updateQueueState";
 
         try {
             int rowcount = 0;

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DatabaseDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DatabaseDialect.java
@@ -87,7 +87,7 @@ public interface DatabaseDialect {
      * @param con
      *        - database connection
      * @return
-     * @throws Exception
+     * @throws SQLException
      */
     public List<Workflow<?>> queryAllActive(String className, Connection con, int max) throws SQLException;
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DerbyDbDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DerbyDbDialect.java
@@ -205,4 +205,21 @@ public class DerbyDbDialect extends AbstractSqlDialect {
         }
         return queryStmt;
     }
+
+    @Override
+    protected void lock(Connection con, String lockContext) throws SQLException {
+        if (!multiEngineMode) {
+            return;
+        }
+        logger.warn("DerbyDbDialect doesn't support multiple engine yet");
+        // TODO implement lock for DerbyDbDialet
+    }
+
+    @Override
+    protected void releaseLock(Connection con, String lockContext) {
+        if (!multiEngineMode) {
+            return;
+        }
+        // TODO
+    }
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/H2Dialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/H2Dialect.java
@@ -184,4 +184,22 @@ public class H2Dialect extends AbstractSqlDialect {
         return queryStmt;
     }
 
+    @Override
+    protected void lock(Connection con, String lockContext) throws SQLException {
+        if (!multiEngineMode) {
+            return;
+        }
+        logger.warn("H2Dialet doesn't support multiple engine yet");
+        // TODO implement lock for H2Dialet
+    }
+
+    @Override
+    protected void releaseLock(Connection con, String lockContext) {
+        if (!multiEngineMode) {
+            return;
+        }
+        // TODO
+
+    }
+
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/MySqlDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/MySqlDialect.java
@@ -108,7 +108,7 @@ public class MySqlDialect extends AbstractSqlDialect {
      * release the lock automatically.
      * If you try to lock multiple times on the same lockContext, for the same connection, you need to release multiple
      * times, it won't deadlock since version 5.7.5, please consult:
-     * {@linkplain http://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock}
+     * http://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock
      */
     @Override
     protected void lock(Connection con, final String lockContext) throws SQLException {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/MySqlDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/MySqlDialect.java
@@ -17,6 +17,7 @@ package org.copperengine.core.persistent;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.Timestamp;
@@ -27,14 +28,19 @@ import org.copperengine.core.DuplicateIdException;
 import org.copperengine.core.Response;
 import org.copperengine.core.Workflow;
 import org.copperengine.core.batcher.BatchCommand;
-
+import org.copperengine.core.db.utility.JdbcUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 /**
  * MySQL implementation of the {@link DatabaseDialect} interface.
  *
  * @author austermann
  */
 public class MySqlDialect extends AbstractSqlDialect {
+    private static final Logger logger = LoggerFactory.getLogger(MySqlDialect.class);
+    private static final int ACQUIRE_BLOCKING_WAIT_SEC = 15;
 
+    @Override
     protected PreparedStatement createUpdateStateStmt(final Connection c, final int max) throws SQLException {
         final Timestamp NOW = new Timestamp(System.currentTimeMillis());
         PreparedStatement pstmt = c.prepareStatement(queryUpdateQueueState + " LIMIT 0," + max);
@@ -43,12 +49,14 @@ public class MySqlDialect extends AbstractSqlDialect {
         return pstmt;
     }
 
+    @Override
     protected PreparedStatement createDequeueStmt(final Connection c, final String ppoolId, final int max) throws SQLException {
         PreparedStatement dequeueStmt = c.prepareStatement("select id,priority,data,object_state,creation_ts from COP_WORKFLOW_INSTANCE where id in (select WORKFLOW_INSTANCE_ID from COP_QUEUE where ppool_id = ? order by priority, last_mod_ts) LIMIT 0," + max);
         dequeueStmt.setString(1, ppoolId);
         return dequeueStmt;
     }
 
+    @Override
     protected PreparedStatement createDeleteStaleResponsesStmt(final Connection c, final int MAX_ROWS) throws SQLException {
         PreparedStatement stmt = c.prepareStatement("delete from COP_RESPONSE where response_timeout < ? and not exists (select * from COP_WAIT w where w.correlation_id = COP_RESPONSE.correlation_id LIMIT " + MAX_ROWS + ")");
         stmt.setTimestamp(1, new Timestamp(System.currentTimeMillis()));
@@ -94,5 +102,86 @@ public class MySqlDialect extends AbstractSqlDialect {
             queryStmt = c.prepareStatement("select id,state,priority,ppool_id,data,object_state,creation_ts from COP_WORKFLOW_INSTANCE where state in (0,1,2) LIMIT 0," + max);
         }
         return queryStmt;
+    }
+
+    /**
+     * Note: For MySQL the advisory lock only applies to the current connection, if the connection terminates, it will
+     * release the lock automatically.
+     * If you try to lock multiple times on the same lockContext, for the same connection, you need to release multiple
+     * times, it won't deadlock since version 5.7.5, please consult:
+     * {@linkplain http://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_get-lock}
+     */
+    @Override
+    protected void lock(Connection con, final String lockContext) throws SQLException {
+        if (!multiEngineMode) {
+            return;
+        }
+        if (logger.isDebugEnabled())
+            logger.debug("Trying to acquire db lock for '" + lockContext);
+        PreparedStatement stmt = con.prepareStatement("select get_lock(?,?)");
+        stmt.setString(1, lockContext);
+        stmt.setInt(2, ACQUIRE_BLOCKING_WAIT_SEC);
+        try {
+            final ResultSet rs = stmt.executeQuery();
+            while (rs.next()) {
+                final int lockResult = rs.getInt(1);
+                if (lockResult == 1) {
+                    // success
+                    return;
+                }
+
+                final String errorMsgPrefix = "error acquire lock(" + lockContext + "," + ACQUIRE_BLOCKING_WAIT_SEC + "): ";
+                if (rs.wasNull()) {
+                    throw new SQLException(errorMsgPrefix + "unknown");
+                } else if (lockResult == 0) {
+                    // timeout
+                    throw new SQLException(errorMsgPrefix + "timeout");
+                }
+            }
+            // something else must be horribly wrong
+            throw new SQLException("Please check your version of MySQL, to make sure it supports get_lock() & release_lock()");
+        } finally {
+            JdbcUtils.closeStatement(stmt);
+        }
+    }
+
+    @Override
+    protected void releaseLock(Connection con, final String lockContext) {
+        if (!multiEngineMode) {
+            return;
+        }
+        if (logger.isDebugEnabled())
+            logger.debug("Trying to release db lock for '" + lockContext);
+        PreparedStatement stmt = null;
+        try {
+            stmt = con.prepareStatement("select release_lock(?)");
+            stmt.setString(1, lockContext);
+
+            final ResultSet rs = stmt.executeQuery();
+            while (rs.next()) {
+                final int releaseLockResult = rs.getInt(1);
+                if (releaseLockResult == 1) {
+                    // success
+                    return;
+                }
+
+                final String errorMsgPrefix = "error release_lock(" + lockContext + "): ";
+                if (rs.wasNull()) {
+                    throw new SQLException(errorMsgPrefix + "doesn't exist");
+                } else if (releaseLockResult == 0) {
+                    // failed release the lock
+                    throw new SQLException(errorMsgPrefix + "not current connection's lock");
+                }
+            }
+            // something else must be horribly wrong
+            throw new SQLException("Please check your version of MySQL, to make sure it supports get_lock() & release_lock()");
+        } catch (SQLException e) {
+            logger.error("release_lock failed", e);
+        } finally {
+            if (stmt != null) {
+                JdbcUtils.closeStatement(stmt);
+            }
+        }
+
     }
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/MySqlDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/MySqlDialect.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
  */
 public class MySqlDialect extends AbstractSqlDialect {
     private static final Logger logger = LoggerFactory.getLogger(MySqlDialect.class);
-    private static final int ACQUIRE_BLOCKING_WAIT_SEC = 15;
 
     @Override
     protected PreparedStatement createUpdateStateStmt(final Connection c, final int max) throws SQLException {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/OracleDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/OracleDialect.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.copperengine.core.Acknowledge;
-import org.copperengine.core.CopperRuntimeException;
 import org.copperengine.core.DuplicateIdException;
 import org.copperengine.core.EngineIdProvider;
 import org.copperengine.core.ProcessingState;
@@ -538,9 +537,9 @@ public class OracleDialect implements DatabaseDialect, DatabaseDialectMXBean {
 
     @Override
     public List<String> checkDbConsistency(Connection con) throws Exception {
-        if (multiEngineMode)
-            throw new CopperRuntimeException("Cannot check DB consistency when multiEngineMode is turned on!");
-
+        if (multiEngineMode) {
+            logger.warn("Checking DB consistency when multiEngineMode is turned on!");
+        }
         final PreparedStatement dequeueStmt = con.prepareStatement("select id,priority,creation_ts,data,long_data,object_state,long_object_state,PPOOL_ID from COP_WORKFLOW_INSTANCE where state not in (?,?)");
         try {
             final List<String> idsOfBadWorkflows = new ArrayList<String>();

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PostgreSQLDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PostgreSQLDialect.java
@@ -17,6 +17,7 @@ package org.copperengine.core.persistent;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.List;
@@ -26,6 +27,7 @@ import org.copperengine.core.DuplicateIdException;
 import org.copperengine.core.Response;
 import org.copperengine.core.Workflow;
 import org.copperengine.core.batcher.BatchCommand;
+import org.copperengine.core.db.utility.JdbcUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 /**
@@ -100,21 +102,61 @@ public class PostgreSQLDialect extends AbstractSqlDialect {
         return queryStmt;
     }
 
+    /**
+     * ref: https://www.postgresql.org/docs/9.5/static/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS
+     * pg_advisory_lock locks an application-defined resource, which can be identified either by a single 64-bit key
+     * value or two 32-bit key values (note that these two key spaces do not overlap). If another session already holds
+     * a lock on the same resource identifier, this function will wait until the resource becomes available. The lock is
+     * exclusive. Multiple lock requests stack, so that if the same resource is locked three times it must then be
+     * unlocked three times to be released for other sessions' use.
+     * DO NOT USE IT WITHOUT finally { release_lock(lockContext)} or it will be deadlocked!!
+     */
     @Override
-    protected void lock(Connection con, String lockContext) throws SQLException {
+    protected void lock(Connection con, final String lockContext) throws SQLException {
         if (!multiEngineMode) {
             return;
         }
-        logger.warn("PostgreSQLDialet doesn't support multiple engine yet");
-        // TODO implement lock for PostgreSQLDialet
+        if (logger.isDebugEnabled())
+            logger.debug("Trying to acquire db lock for '" + lockContext);
+        final int lockId = computeLockId(lockContext);
+        PreparedStatement stmt = con.prepareStatement("SELECT pg_advisory_lock(?)");
+        stmt.setInt(1, lockId);
+        try {
+            stmt.executeQuery();
+        } finally {
+            JdbcUtils.closeStatement(stmt);
+        }
     }
 
     @Override
-    protected void releaseLock(Connection con, String lockContext) {
+    protected void releaseLock(Connection con, final String lockContext) {
         if (!multiEngineMode) {
             return;
         }
-        // TODO
+        if (logger.isDebugEnabled())
+            logger.debug("Trying to release db lock for '" + lockContext);
+        PreparedStatement stmt = null;
+        final int lockId = computeLockId(lockContext);
+        try {
+            stmt = con.prepareStatement("select pg_advisory_unlock(?)");
+            stmt.setInt(1, lockId);
+
+            final ResultSet rs = stmt.executeQuery();
+            while (rs.next()) {
+                final boolean releaseLockResult = rs.getBoolean(1);
+                if (releaseLockResult) {
+                    // success
+                    return;
+                }
+                throw new SQLException("error pg_advisory_unlock(" + lockId + ")");
+            }
+        } catch (SQLException e) {
+            logger.error("release_lock failed", e);
+        } finally {
+            if (stmt != null) {
+                JdbcUtils.closeStatement(stmt);
+            }
+        }
 
     }
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PostgreSQLDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PostgreSQLDialect.java
@@ -26,13 +26,15 @@ import org.copperengine.core.DuplicateIdException;
 import org.copperengine.core.Response;
 import org.copperengine.core.Workflow;
 import org.copperengine.core.batcher.BatchCommand;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 /**
  * PostgreSQL implementation of the {@link ScottyDBStorageInterface}.
  *
  * @author austermann
  */
 public class PostgreSQLDialect extends AbstractSqlDialect {
+    private static final Logger logger = LoggerFactory.getLogger(PostgreSQLDialect.class);
 
     @Override
     protected PreparedStatement createUpdateStateStmt(final Connection c, final int max) throws SQLException {
@@ -96,5 +98,23 @@ public class PostgreSQLDialect extends AbstractSqlDialect {
             queryStmt = c.prepareStatement("select id,state,priority,ppool_id,data,object_state,creation_ts from COP_WORKFLOW_INSTANCE where state in (0,1,2) LIMIT " + max);
         }
         return queryStmt;
+    }
+
+    @Override
+    protected void lock(Connection con, String lockContext) throws SQLException {
+        if (!multiEngineMode) {
+            return;
+        }
+        logger.warn("PostgreSQLDialet doesn't support multiple engine yet");
+        // TODO implement lock for PostgreSQLDialet
+    }
+
+    @Override
+    protected void releaseLock(Connection con, String lockContext) {
+        if (!multiEngineMode) {
+            return;
+        }
+        // TODO
+
     }
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/lock/PersistentLockManager.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/lock/PersistentLockManager.java
@@ -15,6 +15,8 @@
  */
 package org.copperengine.core.persistent.lock;
 
+import org.copperengine.core.Response;
+
 /**
  * A service to obtain/manager persistent locks, e.g. to functionally synchronize workflow instances.
  * 
@@ -62,7 +64,7 @@ public interface PersistentLockManager {
      *             }
      *         }
      *     }
-     * 
+     *}
      * </pre>
      * 
      * @param lockId

--- a/projects/copper-jmx-interface/src/main/java/org/copperengine/management/PersistentPriorityProcessorPoolMXBean.java
+++ b/projects/copper-jmx-interface/src/main/java/org/copperengine/management/PersistentPriorityProcessorPoolMXBean.java
@@ -43,14 +43,14 @@ public interface PersistentPriorityProcessorPoolMXBean extends ProcessorPoolMXBe
      * Workflow instances that already reside in the transient queue are still processed, i.e.
      * calling this methods runs this processor pool "dry".
      * 
-     * @see PersistentProcessorPool#resumeDequeue()
+     * @see #resumeDequeue()
      */
     public void suspendDequeue();
 
     /**
      * Resumes dequeuing of workflow instances from the storage.
      * 
-     * @see PersistentProcessorPool#suspendDequeue()
+     * @see #suspendDequeue()
      */
     public void resumeDequeue();
 


### PR DESCRIPTION
- add multiEngineMode to abstractSqlDialet, and default to true, because it's very likely the case
- add implementation of MySqlDialect & PostgreSQL using their advisory lock

- TODO didn't bother to make OracleDialect extend abstractSqlDialet.. because I cannot test (no oracle installed)
- TODO didn't update H2 and DerbyDbDialect, cannot test and not much info