### PR TITLE
Make COPPER more open for custom serializers

### DIFF
--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/StackEntry.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/StackEntry.java
@@ -27,9 +27,9 @@ public class StackEntry implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    public transient int jumpNo;
-    public transient Object[] locals;
-    public transient Object[] stack;
+    public int jumpNo;
+    public Object[] locals;
+    public Object[] stack;
 
     public StackEntry(Object[] stack, int jumpNo, Object[] locals) {
         this.jumpNo = jumpNo;

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/StackEntry.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/StackEntry.java
@@ -15,15 +15,17 @@
  */
 package org.copperengine.core;
 
+import java.io.Externalizable;
 import java.io.IOException;
-import java.io.Serializable;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 
 /**
  * For internal use only.
  *
  * @author austermann
  */
-public class StackEntry implements Serializable {
+public class StackEntry implements Externalizable {
 
     private static final long serialVersionUID = 1L;
 
@@ -41,32 +43,39 @@ public class StackEntry implements Serializable {
         this.jumpNo = jumpNo;
     }
 
-    private void readObject(java.io.ObjectInputStream stream) throws IOException, ClassNotFoundException {
-        jumpNo = stream.readInt();
-        int numLocals = stream.readInt();
-        int numStack = stream.readInt();
+    // Externalizable interface requires public default constructor to be given.
+    public StackEntry() {
+        this(0);
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeInt(jumpNo);
+        out.writeInt(locals == null ? 0 : locals.length);
+        out.writeInt(stack == null ? 0 : stack.length);
+        if (locals != null) {
+            for (int i = 0; i < locals.length; ++i)
+                out.writeObject(locals[i]);
+        }
+        if (stack != null) {
+            for (int i = 0; i < stack.length; ++i)
+                out.writeObject(stack[i]);
+        }
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+        jumpNo = in.readInt();
+        int numLocals = in.readInt();
+        int numStack = in.readInt();
         if (numLocals > 0)
             locals = new Object[numLocals];
         if (numStack > 0)
             stack = new Object[numStack];
         for (int i = 0; i < numLocals; ++i)
-            locals[i] = stream.readObject();
+            locals[i] = in.readObject();
         for (int i = 0; i < numStack; ++i)
-            stack[i] = stream.readObject();
-    }
-
-    private void writeObject(java.io.ObjectOutputStream stream) throws IOException {
-        stream.writeInt(jumpNo);
-        stream.writeInt(locals == null ? 0 : locals.length);
-        stream.writeInt(stack == null ? 0 : stack.length);
-        if (locals != null) {
-            for (int i = 0; i < locals.length; ++i)
-                stream.writeObject(locals[i]);
-        }
-        if (stack != null) {
-            for (int i = 0; i < stack.length; ++i)
-                stream.writeObject(stack[i]);
-        }
+            stack[i] = in.readObject();
     }
 
     @Override

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/wfrepo/AbstractWorkflowRepository.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/wfrepo/AbstractWorkflowRepository.java
@@ -301,4 +301,9 @@ public abstract class AbstractWorkflowRepository implements WorkflowRepository, 
     public WorkflowClassInfo getWorkflowInfo(String classname) {
         return getVolatileState().workflowClassInfoMap.get(classname);
     }
+
+
+    public ClassLoader getWorkflowClassLoader() {
+        return getVolatileState().classLoader;
+    }
 }


### PR DESCRIPTION
-It is necessary for a Serialization library to have direct access to the used ClassLoader to load and instantiate classes. So expose ours from the WorkflowRepository

-The member attributes in the StackEntry.java file need to be serialized. Otherwise, we couldn't restore the previous workflow state. Our current implementation defines those fields as transient but writes them down specifically when using Java Serialization. This results in other Serialization libraries either to use the Java routines provided for this class, or to serialize all transient fields as well, or to specifically include those fields for serialization. Either way to go is unnecessary. Those variables shall be serialized, so they shall just not be defined as transient... 
