### PR TITLE
Fix all JavaDoc warnings

### DIFF
--- a/projects/copper-cassandra/cassandra-storage/src/main/java/org/copperengine/core/persistent/cassandra/CassandraEngineFactory.java
+++ b/projects/copper-cassandra/cassandra-storage/src/main/java/org/copperengine/core/persistent/cassandra/CassandraEngineFactory.java
@@ -49,6 +49,7 @@ import com.google.common.base.Suppliers;
  * @author austermann
  *
  * @param <T>
+ *        type of DependencyInjector to be used from the created engine
  */
 public abstract class CassandraEngineFactory<T extends DependencyInjector> extends HybridEngineFactory<T> {
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/Callback.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/Callback.java
@@ -23,6 +23,7 @@ package org.copperengine.core;
  * Callback objects are created using the <code>Workflow.createCallback()</code>.
  *
  * @param <E>
+ *        type of data held in the response.
  * @author austermann
  */
 public interface Callback<E> {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/PersistentProcessingEngine.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/PersistentProcessingEngine.java
@@ -33,7 +33,7 @@ public interface PersistentProcessingEngine extends ProcessingEngine {
      * @param con
      *        connection used for the inserting the workflow to the database
      * @throws CopperException
-     *         if the engine can not run the workflow, e.g. in case of a unkown processor pool id
+     *         if the engine can not run the workflow, e.g. in case of a unknown processor pool id
      * @throws DuplicateIdException
      *         if a workflow instance with the same id already exists
      * @return workflow instance ID
@@ -48,7 +48,7 @@ public interface PersistentProcessingEngine extends ProcessingEngine {
      * @param con
      *        connection used for the inserting the workflow to the database
      * @throws CopperException
-     *         if the engine can not run the workflow, e.g. in case of a unkown processor pool id
+     *         if the engine can not run the workflow, e.g. in case of a unknown processor pool id
      * @throws DuplicateIdException
      *         if a workflow instance with the same id already exists
      */
@@ -58,7 +58,11 @@ public interface PersistentProcessingEngine extends ProcessingEngine {
      * Trigger restart a workflow instance that is in the error state.
      * 
      * @param workflowInstanceId
+     *        id of workflow which shall be restarted
      * @throws Exception
+     *        any exception happening on this request, like sql connection lost.
+     *        Note: If id doesn't exist or the workflow with this id is not in error/invalid-state, this method just
+     *        returns with doing nothing.
      */
     public void restart(final String workflowInstanceId) throws Exception;
 
@@ -66,6 +70,7 @@ public interface PersistentProcessingEngine extends ProcessingEngine {
      * Trigger restart of all workflow instances that are in error state.
      * 
      * @throws Exception
+     *         {@link #restart(String)}.
      */
     public void restartAll() throws Exception;
 
@@ -80,6 +85,7 @@ public interface PersistentProcessingEngine extends ProcessingEngine {
      * @param c
      *        jdbc connection to use
      * @throws CopperRuntimeException
+     *         any exception occuring in this operation (Like SQL connection lost) will be wrapped into this exception.
      */
     public void notify(Response<?> response, Connection c) throws CopperRuntimeException;
 
@@ -95,6 +101,7 @@ public interface PersistentProcessingEngine extends ProcessingEngine {
      * @param c
      *        jdbc connection to use
      * @throws CopperRuntimeException
+     *         any exception occuring in this operation (Like SQL connection lost) will be wrapped into this exception.
      */
     public void notify(List<Response<?>> responses, Connection c) throws CopperRuntimeException;
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/Response.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/Response.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
  * 
  * @author austermann
  * @param <E>
+ *        type of data held by the response for the user/workflow.
  */
 public class Response<E> implements Serializable {
 
@@ -39,8 +40,23 @@ public class Response<E> implements Serializable {
     /**
      * Constructor.
      * 
+     * @param correlationId
+     *        the correlation ID on which a workflow is or will hopefully be waiting. This is kind of the mapping between
+     *        notification from outside and the workflow inside COPPER.
+     * @param response
+     *        data which shall be passed to the workflow with the response when the workflow continues execution.
+     * @param exception
+     *        Might be set if an exception occurred. So the workflow can query the Response and will know if an error
+     *        somewhere happened.
+     * @param isTimeout
+     *        holds information whether this response was automatically generated from COPPER as a dummy holder to
+     *        notify the workflow that there was no "real" response but the specified timeout was reached
+     * @param metaData
+     *        Might hold some more arbitrary meta data. Usually is just null.
      * @param internalProcessingTimeout
      *        timeout in msec
+     * @param responseId
+     *        unique id of the response. Each response must be unique of course.
      */
     public Response(String correlationId, E response, Exception exception, boolean isTimeout, String metaData, Long internalProcessingTimeout, final String responseId) {
         super();
@@ -58,6 +74,12 @@ public class Response<E> implements Serializable {
 
     /**
      * Creates a new instance.
+     * @param correlationId
+     *        {@link Response#Response(String, Object, Exception, boolean, String, Long, String)}
+     * @param response
+     *        {@link Response#Response(String, Object, Exception, boolean, String, Long, String)}
+     * @param exception
+     *        {@link Response#Response(String, Object, Exception, boolean, String, Long, String)}
      */
     public Response(String correlationId, E response, Exception exception) {
         this(correlationId, response, exception, false, null, null, null);
@@ -65,6 +87,8 @@ public class Response<E> implements Serializable {
 
     /**
      * Creates a new instance with timeout set to true.
+     * @param correlationId
+     *        {@link Response#Response(String, Object, Exception, boolean, String, Long, String)}
      */
     public Response(String correlationId) {
         this(correlationId, null, null, true, null, null, null);
@@ -108,7 +132,7 @@ public class Response<E> implements Serializable {
     }
 
     /**
-     * returns the meta data of this response. Not used by the copper core itself. Applications may use this data
+     * @return the meta data of this response. Not used by the copper core itself. Applications may use this data
      * for monitoring or some custom response handling.
      */
     public String getMetaData() {
@@ -120,9 +144,10 @@ public class Response<E> implements Serializable {
     }
 
     /**
-     * If true, a response is queued temporarily in the 'early response container' if currently no workflow instance is
-     * (yet) waiting
-     * for the responses' correlationId.
+     * @return
+     *         if response is held in early response handling.
+     *         If true, a response is queued temporarily in the 'early response container' if currently no workflow
+     *         instance is (yet) waiting for the responses' correlationId.
      */
     public boolean isEarlyResponseHandling() {
         return earlyResponseHandling;

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/WaitHook.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/WaitHook.java
@@ -37,6 +37,7 @@ public interface WaitHook {
      * @param con
      *            DB connection or null, in case there is no DB connection in the scope
      * @throws Exception
+     *            Any exception which can happen inside of the code of this WaitHook.
      */
     public void onWait(Workflow<?> wf, Connection con) throws Exception;
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/WorkflowFactory.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/WorkflowFactory.java
@@ -20,8 +20,20 @@ package org.copperengine.core;
  * A WorkflowFactory is requested a the corresponding engine.
  *
  * @param <D>
+ *        type of data passed in to the workflow on creation.
  * @author austermann
  */
 public interface WorkflowFactory<D> {
+    /**
+     * @return
+     *         new instance of the workflow
+     * @throws InstantiationException
+     *         {@link Class#newInstance()}
+     *         "if this Class represents an abstract class, an interface, an array class, a primitive type, or void;
+     *         or if the class has no nullary constructor; or if the instantiation fails for some other reason."
+     * @throws IllegalAccessException
+     *         {@link Class#newInstance()}
+     *         "if the class or its nullary constructor is not accessible."
+     */
     public Workflow<D> newInstance() throws InstantiationException, IllegalAccessException;
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/audit/AuditTrail.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/audit/AuditTrail.java
@@ -115,21 +115,30 @@ public interface AuditTrail {
      * @param messageType
      *            type of the message, e.g. XML, used for message rendering in the COPPER monitor
      * @param cb
+     *            callback called when logging succeeded or failed.
      */
     public void asynchLog(int logLevel, Date occurrence, String conversationId, String context, String instanceId, String correlationId, String transactionId, String message, String messageType, AuditTrailCallback cb);
 
     /**
      * returns immediately after queueing the log message
+     * @param e
+     *            the AuditTrailEvent to be logged
      */
     public void asynchLog(AuditTrailEvent e);
 
     /**
      * returns immediately after queueing the log message
+     * @param e
+     *            the AuditTrailEvent to be logged
+     * @param cb
+     *            callback called when logging succeeded or failed.
      */
     public void asynchLog(AuditTrailEvent e, AuditTrailCallback cb);
 
     /**
      * writes an event to the audit trail log and returns after the log message is written to the underlying storage.
+     * @param e
+     *            the AuditTrailEvent to be logged
      */
     public void synchLog(AuditTrailEvent e);
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/audit/AuditTrailCallback.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/audit/AuditTrailCallback.java
@@ -29,6 +29,8 @@ public interface AuditTrailCallback {
 
     /**
      * called by the audit trail, when an asynchronous logging has been failed
+     * @param e
+     *        The Exception which kept the logging from succeeding and which lead to the failure.
      */
     public void error(Exception e);
 }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/AbstractBatchCommand.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/AbstractBatchCommand.java
@@ -18,8 +18,8 @@ package org.copperengine.core.batcher;
 /**
  * Abstract base implementation of {@link BatchCommand}
  *
- * @param <E>
- * @param <T>
+ * @param <E> type of the BatchExecutor
+ * @param <T> type of the BatchCommand to be executed
  * @author austermann
  */
 public abstract class AbstractBatchCommand<E extends BatchExecutor<E, T>, T extends AbstractBatchCommand<E, T>> implements BatchCommand<E, T> {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/BatchCommand.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/BatchCommand.java
@@ -17,27 +17,29 @@ package org.copperengine.core.batcher;
 
 /**
  * A BatchCommand is one task executed in a Batch.
- * BatchCommands with the same executor are batched by the {@link Batcher}
+ * BatchCommands with the same executor are batched by the {@link Batcher}.
+ * Usually, a BatchCommand should hold the data unique to each command, where the executor holds the sql-queries and
+ * puts the data from all commands into the queries.
  *
- * @param <E>
- * @param <T>
+ * @param <E> type of the BatchExecutor
+ * @param <T> type of the BatchCommand to be executed
  * @author austermann
  */
 public interface BatchCommand<E extends BatchExecutorBase<E, T>, T extends BatchCommand<E, T>> {
 
     /**
-     * returns the executor for this BatchCommand.
+     * @return the executor for this BatchCommand.
      */
     E executor();
 
     /**
-     * returns the callback called by the batcher, after this command has been processed. Used for asynchronously
+     * @return the callback called by the batcher, after this command has been processed. Used for asynchronously
      * notifying the caller.
      */
     CommandCallback<T> callback();
 
     /**
-     * returns the targetTime timestamp in java milliseconds until which this batch command shall be executed.
+     * @return the targetTime timestamp in java milliseconds until which this batch command shall be executed.
      * This value influences how long the used batcher is collecting BatchCommands with the same executor.
      */
     long targetTime();

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/BatchExecutor.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/BatchExecutor.java
@@ -21,8 +21,8 @@ import java.util.Collection;
 /**
  * Abstract base implementation of the {@link BatchExecutorBase} interface.
  *
- * @param <E>
- * @param <T>
+ * @param <E> type of the BatchExecutor
+ * @param <T> type of the BatchCommand to be executed by the executor implementation
  * @author austermann
  */
 public abstract class BatchExecutor<E extends BatchExecutor<E, T>, T extends BatchCommand<E, T>> implements BatchExecutorBase<E, T> {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/BatchExecutorBase.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/BatchExecutorBase.java
@@ -22,18 +22,23 @@ import java.util.Collection;
  * Base interface of a BatchExecutor. A batch executor is responsible to process a batch of {@link BatchCommand}s.
  * A batcher is responsible to collect a batch of commands and call their executor to execute the batch.
  *
- * @param <T>
+ * @param <E> type of the BatchExecutorBase
+ * @param <T> type of the BatchCommand to be executed by the executor implementation
  * @author austermann
  */
 public interface BatchExecutorBase<E extends BatchExecutorBase<E, T>, T extends BatchCommand<E, T>> {
 
     /**
      * Executes a batch of commands
+     * @param commands  the batch of commands is collected by the batcher and passed in to this method which can then
+     *                  execute them all in one batch.
+     * @param connection the connection to work on
+     * @throws Exception any kind of uncaught exception with the implementation of the executor
      */
     void doExec(Collection<BatchCommand<E, T>> commands, Connection connection) throws Exception;
 
     /**
-     * Preferred batch size of this executor
+     * @return Preferred batch size of this executor
      */
     int preferredBatchSize();
 
@@ -45,7 +50,7 @@ public interface BatchExecutorBase<E extends BatchExecutorBase<E, T>, T extends 
     boolean prioritize();
 
     /**
-     * Unique ID of this batcher.
+     * @return unique ID of this batcher.
      */
     String id();
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/CommandCallback.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/CommandCallback.java
@@ -19,7 +19,7 @@ package org.copperengine.core.batcher;
  * Callback interface for notifying a caller about the result of a batch command.
  * 
  * @author austermann
- * @param <T>
+ * @param <T> type of the BatchCommand to be executed by the executor implementation
  */
 public interface CommandCallback<T extends BatchCommand<?, T>> {
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/NullCallback.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/NullCallback.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  * Mock implementation of the {@link CommandCallback} interface.
  * Successful command executions are ignored, exceptions are logged.
  *
- * @param <T>
+ * @param <T> type of the BatchCommand
  * @author austermann
  */
 public class NullCallback<T extends BatchCommand<?, T>> implements CommandCallback<T> {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/RetryingTxnBatchRunner.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/batcher/RetryingTxnBatchRunner.java
@@ -34,7 +34,10 @@ public class RetryingTxnBatchRunner<E extends BatchExecutorBase<E, T>, T extends
     public RetryingTxnBatchRunner() {
     }
 
-    /** @since 3.1 */
+    /**
+     * @param dataSource on which the RetryingTxnBatchRunner operates on.
+     * @since 3.1
+     * */
     public RetryingTxnBatchRunner(DataSource dataSource) {
         this.dataSource = dataSource;
     }

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/common/AbstractJmxExporter.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/common/AbstractJmxExporter.java
@@ -71,28 +71,44 @@ public abstract class AbstractJmxExporter {
         }
     }
 
-    /** return a map with entries { "name" -&gt; WorkflowRepositoryMXBean }. The map may be empty. */
+    /**
+     * @return a map with entries { "name" -&gt; WorkflowRepositoryMXBean }. The map may be empty.
+     */
     protected abstract Map<String, WorkflowRepositoryMXBean> getWorkflowRepositoryMXBeans();
 
-    /** return a map with entries { "name" -&gt; ProcessingEngineMXBean }. The map may be empty. */
+    /**
+     * @return a map with entries { "name" -&gt; ProcessingEngineMXBean }. The map may be empty.
+     */
     protected abstract Map<String, ProcessingEngineMXBean> getProcessingEngineMXBeans();
 
-    /** return a map with entries { "name" -&gt; ProcessorPoolMXBean }. The map may be empty. */
+    /**
+     * @return a map with entries { "name" -&gt; ProcessorPoolMXBean }. The map may be empty.
+     */
     protected abstract Map<String, ProcessorPoolMXBean> getProcessorPoolMXBeans();
 
-    /** return a map with entries { "name" -&gt; StatisticsCollectorMXBean }. The map may be empty. */
+    /**
+     * @return a map with entries { "name" -&gt; StatisticsCollectorMXBean }. The map may be empty.
+     */
     protected abstract Map<String, StatisticsCollectorMXBean> getStatisticsCollectorMXBeans();
 
-    /** return a map with entries { "name" -&gt; AuditTrailMXBean }. The map may be empty. */
+    /**
+     * @return a map with entries { "name" -&gt; AuditTrailMXBean }. The map may be empty.
+     */
     protected abstract Map<String, AuditTrailMXBean> getAuditTrailMXBeans();
 
-    /** return a map with entries { "name" -&gt; BatcherMXBean }. The map may be empty. */
+    /**
+     * @return a map with entries { "name" -&gt; BatcherMXBean }. The map may be empty.
+     */
     protected abstract Map<String, BatcherMXBean> getBatcherMXBeans();
 
-    /** return a map with entries { "name" -&gt; DatabaseDialectMXBean }. The map may be empty. */
+    /**
+     * @return a map with entries { "name" -&gt; DatabaseDialectMXBean }. The map may be empty.
+     */
     protected abstract Map<String, DatabaseDialectMXBean> getDatabaseDialectMXBeans();
 
-    /** return a map with entries { "name" -&gt; AuditTrailQueryMXBean }. The map may be empty. */
+    /**
+     * @return a map with entries { "name" -&gt; AuditTrailQueryMXBean }. The map may be empty.
+     */
     protected abstract Map<String, AuditTrailQueryMXBean> getAuditTrailQueryMXBeans();
 
     private void register(MBeanServer mBeanServer, Map<String, ?> map, String domain) throws MalformedObjectNameException, InstanceAlreadyExistsException, MBeanRegistrationException, NotCompliantMBeanException {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/common/DefaultProcessorPoolManager.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/common/DefaultProcessorPoolManager.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Default implementation of the {@link ProcessorPoolManager} interface.
  *
- * @param <T>
+ * @param <T> type of processor pool to be managed
  * @author austermann
  */
 public class DefaultProcessorPoolManager<T extends ProcessorPool> implements ProcessorPoolManager<T> {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/common/DefaultTicketPoolManager.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/common/DefaultTicketPoolManager.java
@@ -108,6 +108,9 @@ public class DefaultTicketPoolManager implements TicketPoolManager {
      * For testing..
      *
      * @param wf
+     *        For this workflow, the corresponding ticketPool is searched and then a ticket is obtained from this pool.
+     * @return
+     *        id of the ticket pool.
      */
     public String obtainAndReturnTicketPoolId(Workflow<?> wf) {
         TicketPool tp = findPool(wf.getClass().getName());

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/common/IdFactory.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/common/IdFactory.java
@@ -23,6 +23,8 @@ package org.copperengine.core.common;
 public interface IdFactory {
     /**
      * creates a new id
+     * @return
+     *        A new id
      */
     public String createId();
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/common/PriorityProcessorPool.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/common/PriorityProcessorPool.java
@@ -60,6 +60,9 @@ public abstract class PriorityProcessorPool implements ProcessorPool, ProcessorP
     /**
      * Creates a new {@link PriorityProcessorPool} with as many worker threads as processors available on the
      * corresponding environment.
+     * @param id
+     *        id for the new created pool. Must be unique and shall not be longer than 32 characters which is the limit
+     *        to be stored for the processor pool ids when using persistent engines.
      */
     public PriorityProcessorPool(String id) {
         super();
@@ -74,6 +77,8 @@ public abstract class PriorityProcessorPool implements ProcessorPool, ProcessorP
 
     /**
      * Creates a new instance of {@link WfPriorityQueue}
+     * @return
+     *        the new created instance.
      */
     protected Queue<Workflow<?>> createQueue() {
         return new WfPriorityQueue();

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/common/ProcessorPool.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/common/ProcessorPool.java
@@ -26,11 +26,13 @@ public interface ProcessorPool {
 
     /**
      * Called internally by COPPER during initialization
+     * @param engine
+     *        engine which holds the ProcessorPool
      */
     public void setEngine(ProcessingEngine engine);
 
     /**
-     * returns the processor pools identifier
+     * @return the processor pools identifier
      */
     public String getId();
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/common/ProcessorPoolManager.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/common/ProcessorPoolManager.java
@@ -23,7 +23,7 @@ import org.copperengine.core.ProcessingEngine;
 /**
  * Interface for managing {@link ProcessorPool}s in one COPPER {@link ProcessingEngine}.
  *
- * @param <T>
+ * @param <T> type of ProcessorPool hold by the manager
  * @author austermann
  */
 public interface ProcessorPoolManager<T extends ProcessorPool> {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/common/TicketPool.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/common/TicketPool.java
@@ -98,6 +98,7 @@ public class TicketPool {
      * @param count
      *        number of tickets to obtain. must be 0 &gt; count &lt; maxTickets
      * @throws IllegalArgumentException
+     *        Thrown if, count is &lt; 0 or count &gt; maxTickets when forcing is disabled.
      */
     public void obtain(int count) throws IllegalArgumentException {
         obtain(count, false);
@@ -167,6 +168,7 @@ public class TicketPool {
      * threads, that new tickets are in the pool.
      * 
      * @param count
+     *        number of tickets to be released
      */
     public synchronized void release(int count) {
         used -= count;
@@ -210,7 +212,7 @@ public class TicketPool {
      * monitoring wait times via
      * JMX {@link Notification}s
      * 
-     * @param traceEnabled
+     * @param traceEnabled boolean to be set if tracing via JMX is desired
      * @see #setNotificationBroadcasterSupport(NotificationBroadcasterSupport)
      */
     public synchronized void setTraceEnabled(boolean traceEnabled) {
@@ -222,7 +224,7 @@ public class TicketPool {
      * allow monitoring wait
      * times via JMX {@link Notification}s
      * 
-     * @param nbs
+     * @param nbs NotificationBroadcasterSupport to be set if monitoring wait via JMX is desired
      * @see #setTraceEnabled(boolean)
      */
     public void setNotificationBroadcasterSupport(NotificationBroadcasterSupport nbs) {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/db/utility/JdbcUtils.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/db/utility/JdbcUtils.java
@@ -29,6 +29,8 @@ public abstract class JdbcUtils {
     /**
      * Close the given JDBC Connection and ignore any thrown exception.
      * This is useful for typical finally blocks in manual JDBC code.
+     * @param con
+     *        Connection which shall be closed
      */
     public static void closeConnection(Connection con) {
         if (con != null) {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/db/utility/RetryingTransaction.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/db/utility/RetryingTransaction.java
@@ -88,6 +88,10 @@ public abstract class RetryingTransaction<R> implements Transaction<R> {
      *       }
      *    }.run();
      *    </code>
+     * @return
+     *         any type which shall be passed back after execution succeeded.
+     * @throws Exception
+     *         Any exception which could happen in an implementation of this method
      */
     protected abstract R execute() throws Exception;
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/monitoring/LoggingStatisticCollector.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/monitoring/LoggingStatisticCollector.java
@@ -73,7 +73,8 @@ public class LoggingStatisticCollector implements RuntimeStatisticsCollector, St
     }
 
     /**
-     * If set to true, the internal statistics are reseted after a each periodical logging.
+     * @param resetAfterLogging
+     *        If set to true, the internal statistics are reseted after a each periodical logging.
      */
     public void setResetAfterLogging(boolean resetAfterLogging) {
         this.resetAfterLogging = resetAfterLogging;

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/monitoring/StmtStatistic.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/monitoring/StmtStatistic.java
@@ -38,7 +38,9 @@ public class StmtStatistic {
      * creates a new StmtStatistic with a name only.
      *
      * @param measurePointId
+     *        new name of the StmtStatistic. Must not be null.
      * @param runtimeStatisticsCollector
+     *        statistics collector for this StmtStatistic. Must not be null.
      */
     public StmtStatistic(final String measurePointId, final RuntimeStatisticsCollector runtimeStatisticsCollector) {
         if (measurePointId == null)

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/AbstractSqlDialect.java
@@ -158,7 +158,9 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
     }
 
     /**
-     * returns an int value between 0 and 1073741823 (exclusive)
+     * @param s
+     *        a given lock id string from which a integer id shall be generated (Using s.hashCode())
+     * @return an int value between 0 and 1073741823 (exclusive)
      */
     protected static int computeLockId(String s) {
         // This method handles the following fact: Math.abs(Integer.MIN_VALUE) == Integer.MIN_VALUE
@@ -430,8 +432,11 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
      * It will block wait until the lock was successfully hold, must be used together with {@link #releaseLock}
      * 
      * @param con
+     *        connection object on which the lock will be acquired on
      * @param lockContext
+     *        String for the lock name (Will be transformed to an int by {@link #computeLockId(String)}.
      * @throws SQLException
+     *        If anything goes wrong in acquiring the lock on the database
      */
     protected void doLock(Connection con, String lockContext) throws SQLException {
         throw new UnsupportedOperationException();
@@ -441,7 +446,9 @@ public abstract class AbstractSqlDialect implements DatabaseDialect, DatabaseDia
      * Releases the lock on the lockContext, use together with {@link #lock(Connection, String)}
      * 
      * @param con
+     *        connection object on which the lock will be released on
      * @param lockContext
+     *        String for the lock name
      */
     protected void doReleaseLock(Connection con, String lockContext) {
         throw new UnsupportedOperationException();

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DatabaseDialect.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DatabaseDialect.java
@@ -60,7 +60,8 @@ public interface DatabaseDialect {
     public abstract BatchCommand createBatchCommand4error(Workflow<?> w, Throwable t, DBProcessingState dbProcessingState, final Acknowledge callback);
 
     /**
-     * If true (default), finished workflow instances are removed from the database.
+     * @param removeWhenFinished
+     *        If true (default), finished workflow instances are removed from the database.
      */
     public void setRemoveWhenFinished(boolean removeWhenFinished);
 
@@ -72,6 +73,7 @@ public interface DatabaseDialect {
      *        database connection
      * @return list of ids of bad workflows which could not be deserialized
      * @throws Exception
+     *         For any SQL error like losing connection or such.
      */
     public List<String> checkDbConsistency(Connection con) throws Exception;
 
@@ -85,18 +87,29 @@ public interface DatabaseDialect {
      * Query workflows that were active at the moment in (ENQUEUE, RUNNING or WAITING) state
      * 
      * @param className
-     *        - optional, specify which className it want to return
+     *        - optional, specify which className it want to return. May be null. (No filtering for class name done in this case)
+     *        If specified, the className must fully match the class name, so no regexp or similar is allowed.
+     *        className must be given as fully qualified name (i.e. with package names prepending).
+     *        Example is {@code org.copperengine.examples.workflows.MyWorkflow}
      * @param con
      *        - database connection
+     * @param max
+     *        maximum number to be queried (Translates to LIMIT max or FETCH ,max or similar on SQL queries SELECT)
      * @return
+     *        List of active workflows.
      * @throws SQLException
+     *         If anything goes wrong regarding SQL.
      */
     public List<Workflow<?>> queryAllActive(String className, Connection con, int max) throws SQLException;
     
     /**
      * Read the current system time from the underlying database system
+     * @param con
+     *        database connection
      * @return
+     *         Current database clock time
      * @throws SQLException
+     *         Any sql error happening in here.
      */
     public Date readDatabaseClock(Connection con) throws SQLException;
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DefaultEntityPersisterFactory.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DefaultEntityPersisterFactory.java
@@ -34,6 +34,8 @@ public interface DefaultEntityPersisterFactory<E, P extends DefaultEntityPersist
 
     /**
      * Needed to be able to return the created persister as a mapper (see {@link PersistenceContext#getMapper(Class)}).
+     * @return
+     *        the persister class
      */
     Class<?> getPersisterClass();
 
@@ -47,6 +49,8 @@ public interface DefaultEntityPersisterFactory<E, P extends DefaultEntityPersist
      *            {@link PersistentWorkflow#onSave(PersistenceContext)} methods.
      * @param sharedRessources
      *            shared ressources; should come from a preceeding call to {@link #createSharedRessources()}
+     * @return
+     *        the newly created persister as subclass of a DefaultEntityPersister
      */
     P createPersister(PersistentWorkflow<?> workflow, DefaultPersisterSharedRessources<E, P> sharedRessources);
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DefaultPersistenceWorker.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/DefaultPersistenceWorker.java
@@ -28,7 +28,9 @@ import org.copperengine.core.persistent.EntityPersister.PostSelectedCallback;
  * {@link DefaultEntityPersisterFactory}.
  *
  * @param <E>
+ *        type of entity
  * @param <P>
+ *        subtype of EntitityPersister
  * @author Roland Scheel
  */
 public abstract class DefaultPersistenceWorker<E, P extends EntityPersister<E>> {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/EntityPersister.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/EntityPersister.java
@@ -20,6 +20,7 @@ package org.copperengine.core.persistent;
  * 
  * @author Roland Scheel
  * @param <E>
+ *        type of entity
  */
 public interface EntityPersister<E> {
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/MementoUtil.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/MementoUtil.java
@@ -52,6 +52,7 @@ public class MementoUtil {
      * Remember this entity after loading
      *
      * @param entity
+     *        The entity to be remembered
      */
     public void addMementoEntity(Object entity) {
         memento.put(identifier(entity), new Object[] { entity });
@@ -61,6 +62,7 @@ public class MementoUtil {
      * Use this entity as the new
      *
      * @param entity
+     *        the entity to be used as the new
      */
     public void addCurrentEntity(Object entity) {
         Object identifier = identifier(entity);

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistenceContext.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistenceContext.java
@@ -26,7 +26,9 @@ public interface PersistenceContext {
     /**
      * retrieves the persister assigned to this entity class. Throws a runtime exception when no persister can be
      * returned
-     * 
+     *
+     * @param <T>
+     *            type of entity
      * @param entityClass
      *            The entity class to look up the persister for
      * @return the persister

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistenceContextFactory.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistenceContextFactory.java
@@ -25,6 +25,7 @@ import java.sql.SQLException;
  * 
  * @author Roland Scheel
  * @param <T>
+ *         subtype of PersistenceContext
  */
 public interface PersistenceContextFactory<T extends PersistenceContext> {
 
@@ -32,6 +33,7 @@ public interface PersistenceContextFactory<T extends PersistenceContext> {
      * Creates a persistence context for use during loading of workflows.
      * 
      * @param workflow
+     *        the workflow for which the context is created
      * @return the created context
      */
     T createPersistenceContextForLoading(PersistentWorkflow<?> workflow);
@@ -40,6 +42,7 @@ public interface PersistenceContextFactory<T extends PersistenceContext> {
      * Creates a persistence context for use during saving of workflows.
      * 
      * @param workflow
+     *        the workflow for which the context is created
      * @return the created context
      */
     T createPersistenceContextForSaving(PersistentWorkflow<?> workflow);
@@ -48,6 +51,7 @@ public interface PersistenceContextFactory<T extends PersistenceContext> {
      * Creates a persistence context for use during deletion of workflows.
      * 
      * @param workflow
+     *        the workflow for which the context is created
      * @return the created context
      */
     T createPersistenceContextForDeletion(PersistentWorkflow<?> workflow);
@@ -56,6 +60,7 @@ public interface PersistenceContextFactory<T extends PersistenceContext> {
      * Flushes all operations that were passed to the created {@link PersistenceContext}s.
      * 
      * @throws SQLException
+     *         for any SQL exception happening during this operation
      */
     void flush() throws SQLException;
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentPriorityProcessorPool.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentPriorityProcessorPool.java
@@ -67,6 +67,12 @@ public class PersistentPriorityProcessorPool extends PriorityProcessorPool imple
     /**
      * Creates a new {@link PersistentPriorityProcessorPool} with as many worker threads as processors available on the
      * corresponding environment.
+     * @param id
+     *        unique id of the newly created processor pool. (Must not be longer than 32 chars to be stored in database)
+     * @param transactionController
+     *        transaction controller which shall handle the transactions for workflows in between two checkpoints (i.e. between
+     *        two calls to wait/resubmit/savepoint or from start to first occurence of those, or from last occurence to end).
+     *        The transaction controller is only held in this class but used by the {@link PersistentProcessor}s.
      */
     public PersistentPriorityProcessorPool(String id, TransactionController transactionController) {
         super(id);

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentScottyEngine.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentScottyEngine.java
@@ -68,6 +68,8 @@ public class PersistentScottyEngine extends AbstractProcessingEngine implements 
     private final AtomicLong sequenceIdFactory = new AtomicLong(System.currentTimeMillis() * 10000L);
 
     /**
+     * @param notifyProcessorPoolsOnResponse
+     *        specify if processor pools shall be notified on response
      * @deprecated without effect - will be removed in future release
      */
     public void setNotifyProcessorPoolsOnResponse(boolean notifyProcessorPoolsOnResponse) {
@@ -239,7 +241,9 @@ public class PersistentScottyEngine extends AbstractProcessingEngine implements 
      * @param con
      *        connection used for the inserting the workflow to the database
      * @throws CopperException
-     *         if the engine can not run the workflow, e.g. in case of a unkown processor pool id
+     *         if the engine can not run the workflow, e.g. in case of a unknown processor pool id
+     * @return
+     *         workflow id
      */
     public String run(Workflow<?> wf, Connection con) throws CopperException {
         if (logger.isTraceEnabled())
@@ -495,6 +499,9 @@ public class PersistentScottyEngine extends AbstractProcessingEngine implements 
     @Override
     protected WorkflowInfo convert2Wfi(Workflow<?> wf) {
         WorkflowInfo wfi = super.convert2Wfi(wf);
+        if (wfi == null) {
+            return null;
+        }
         ErrorData errorData = ((PersistentWorkflow<?>)wf).getErrorData();
         if (errorData != null) {
             org.copperengine.management.model.ErrorData x = new org.copperengine.management.model.ErrorData();

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentWorkflow.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/PersistentWorkflow.java
@@ -33,6 +33,7 @@ import org.copperengine.core.Workflow;
  * workflow needs persistence or not, it is OK to inherit from PersistentWorkflow.
  * 
  * @param <E>
+ *        type of data object holt by the workflow (Passed in when calling {@link org.copperengine.core.ProcessingEngine#run}
  * @author austermann
  */
 public abstract class PersistentWorkflow<E extends Serializable> extends Workflow<E> implements Serializable, SavepointAware {
@@ -63,6 +64,8 @@ public abstract class PersistentWorkflow<E extends Serializable> extends Workflo
 
     /**
      * Used internally
+     * @param data
+     *        Just hard cast data to (E). On internal call, we know that data is of correct type, even when handling as object.
      */
     @SuppressWarnings("unchecked")
     public void setDataAsObject(Object data) {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/ScottyDBStorageInterface.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/ScottyDBStorageInterface.java
@@ -35,29 +35,70 @@ public interface ScottyDBStorageInterface {
     /**
      * Inserts a new workflow to the underlying database. The implementation may execute the inserts outside the callers
      * context. The completion will be signalled through the Acknowledge object.
+     * @param wf
+     *        workflow to be inserted
+     * @param ack
+     *         acknowledgment to notify about success or exception.
+     * @throws DuplicateIdException
+     *         If a workflow with the same id as the id of wf is already stored in the database.
+     * @throws Exception
+     *         For all kinds of other exceptions like losing database connection
      */
     public void insert(final Workflow<?> wf, Acknowledge ack) throws DuplicateIdException, Exception;
 
     /**
      * Inserts a list of new workflows to the underlying database. The implementation may execute the inserts outside
      * the callers context. The completion will be signalled through the Acknowledge object.
+     * @param wfs
+     *        workflows to be inserted
+     * @param ack
+     *         acknowledgment to notify about success or exception.
+     * @throws DuplicateIdException
+     *         If a workflow with the same id as the id of wf is already stored in the database.
+     * @throws Exception
+     *         For all kinds of other exceptions like losing database connection
      */
     public void insert(final List<Workflow<?>> wfs, Acknowledge ack) throws DuplicateIdException, Exception;
 
     /**
      * Inserts a new workflow to the underlying database using the provided connection.
      * It is up to the caller commit or rollback and close the connection.
+     * @param wf
+     *        workflow to be inserted
+     * @param con
+     *         Connection object on which insertion shall happen. With connection as parameter, the caller get
+     *         full commit/rollback control and can thus make use of stronger insertion guarantees than possible
+     *         with using Acknowledgments only.
+     * @throws DuplicateIdException
+     *         If a workflow with the same id as the id of wf is already stored in the database.
+     * @throws Exception
+     *         For all kinds of other exceptions like losing database connection
      */
     public void insert(final Workflow<?> wf, Connection con) throws DuplicateIdException, Exception;
 
     /**
      * Inserts a list of new workflows to the underlying database using the provided connection.
      * It is up to the caller commit or rollback and close the connection.
+     * @param wfs
+     *        workflows to be inserted
+     * @param con
+     *         Connection object on which insertion shall happen. With connection as parameter, the caller get
+     *         full commit/rollback control and can thus make use of stronger insertion guarantees than possible
+     *         with using Acknowledgments only.
+     * @throws DuplicateIdException
+     *         If a workflow with the same id as the id of wf is already stored in the database.
+     * @throws Exception
+     *         For all kinds of other exceptions like losing database connection
      */
     public void insert(final List<Workflow<?>> wfs, Connection con) throws DuplicateIdException, Exception;
 
     /**
-     * Marks a workflow instance as finished or removes it from the underlying database.
+     * Marks a workflow instance as finished or removes it from the underlying database. (Depending on how
+     * {@link AbstractSqlDialect#setRemoveWhenFinished} is set. Default is to delete).
+     * @param w
+     *        workflow instance which finished
+     * @param callback
+     *        which is called after operation succeeded or an Exception occurred.
      */
     public void finish(final Workflow<?> w, final Acknowledge callback);
 
@@ -65,29 +106,70 @@ public interface ScottyDBStorageInterface {
      * Dequeues up to <code>max</code> Workflow instances for the specified processor pool from the database.
      * It dequeues only such workflow instances that need further processing, e.g. when a response arrived or
      * a timeout occured.
+     * @param ppoolId
+     *        the processor pool id of the processor pool to which the workflows shall be dequeued
+     * @param max
+     *        maximum number of workflows which shall be dequeud by this call
+     * @return
+     *        List of workflows dequeued from database storage
+     * @throws Exception
+     *        Any exception which could happen in this procedure like losing database connection.
      */
     public List<Workflow<?>> dequeue(final String ppoolId, final int max)
             throws Exception;
 
     /**
      * Asynchronous service to add a {@link Response} to the database.
+     * Regarding to our best practices, this method should be called from "outside COPPER" from some user implemented adapter.
+     * @param response
+     *        the response which holds the correlation ID (required to know which workflow is to be waken up if all wait-
+     *        conditions are met) and the data which shall be provided to the workflow
+     * @param ack
+     *        An {@link Acknowledge} which is notified after a successful operation run or about the exception which occured otherwise.
+     * @throws Exception
+     *        Any exception which could happen in this procedure like losing database connection.
+     *
      */
     public void notify(final Response<?> response, final Acknowledge ack)
             throws Exception;
 
     /**
      * Asynchronous service to add a list of {@link Response}s to the database.
+     * @param response
+     *        the list of responses for which each holds the correlation ID (required to know which workflow is to be waken up if all wait-
+     *        conditions are met) and the data which shall be provided to the workflow
+     * @param ack
+     *        An {@link Acknowledge} which is notified after a successful operation run or about the exception which occured otherwise.
+     * @throws Exception
+     *        Any exception which could happen in this procedure like losing database connection.
      */
     public void notify(final List<Response<?>> response, final Acknowledge ack) throws Exception;
 
     /**
      * Synchronous service to add a list of {@link Response}s to the database using a provided database connection.
+     * @param responses
+     *        the responses for which each holds the correlation ID (required to know which workflow is to be waken up if all wait-
+     *        conditions are met) and the data which shall be provided to the workflow
+     * @param c
+     *        Connection object on which notify shall happen. With connection as parameter, the caller get
+     *        full commit/rollback control and can thus make use of stronger notification-guarantees than possible
+     *        with using Acknowledgments only.
+     * @throws Exception
+     *        Any exception which could happen in this procedure like losing database connection.
      */
     public void notify(List<Response<?>> responses, Connection c) throws Exception;
 
     /**
      * Writes a workflow instance that is waiting for one or more asynchronous response back to
      * database.
+     * @param rc
+     *        class for holding information about the workflow which shall be updated in its processing state. Holds the
+     *        workflow itself but also more data like the correlation IDs to wait upon and more. All data required for
+     *        the database update is stored in here.
+     * @param callback
+     *        Callback which is called on success or error after this operation finished.
+     * @throws Exception
+     *         Any unexpected Exception like losing database connection.
      */
     public void registerCallback(final RegisterCall rc, final Acknowledge callback) throws Exception;
 
@@ -104,23 +186,35 @@ public interface ScottyDBStorageInterface {
     /**
      * Marks a workflow instance as failed in the database. It may me triggered again later when the
      * error cause has been solved using the <code>restart</code> method.
+     * @param w
+     *        The workflow which shall be marked as erroneous
+     * @param t
+     *        The Throwable which lead the workflow get into this error state.
+     * @param callback
+     *        callback which notifies about success or error within this operation after it finished.
      */
     public void error(final Workflow<?> w, Throwable t, final Acknowledge callback);
 
     /**
-     * Triggers the restart of a failed workflow instance.
+     * Triggers the restart of a failed workflow instance, i.e. resubmitting the given workflow in DBProcessingState.INVALID
+     * or DBProcessingState.ERROR to the queue to (re-)start from last stored execution point.
+     * @param workflowInstanceId
+     *        workflow id of broken workflow
+     * @throws Exception
+     *         Any Exception like losing database connection.
      */
     public void restart(final String workflowInstanceId) throws Exception;
 
     /**
-     * If true (default), finished workflow instances are removed from the database.
+     * @param removeWhenFinished If true (default), finished workflow instances are removed from the database.
      */
     public void setRemoveWhenFinished(boolean removeWhenFinished);
 
     /**
-     * Triggers the restart of all failed workflow instances.
+     * Triggers the restart of all failed workflow instances. See also {@link #restart(String)}
      * 
      * @throws Exception
+     *         Any Exception like losing database connection.
      */
     public void restartAll() throws Exception;
 
@@ -131,6 +225,7 @@ public interface ScottyDBStorageInterface {
      *        the id of the workflow
      * @return a new deserialized workflow instance
      * @throws Exception
+     *         Any Exception like losing database connection.
      */
     public Workflow<?> read(final String workflowInstanceId) throws Exception;
 
@@ -143,6 +238,7 @@ public interface ScottyDBStorageInterface {
      *        limits the number of Workflow instances to read
      * @return list of deserialized workflow instance
      * @throws Exception
+     *         Any Exception like losing database connection.
      */
     public List<Workflow<?>> queryAllActive(final String className, final int max) throws Exception;
     

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/WorkflowPersistencePlugin.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/WorkflowPersistencePlugin.java
@@ -54,6 +54,8 @@ public interface WorkflowPersistencePlugin {
      * 
      * @param con
      *            The database connection the load operation is bound to.
+     * @param workflows
+     *            list of workflows specified by any Iterable.
      * @throws SQLException
      *             Implementations may pass SQL Exception to be handled by the database dialect
      */

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/lock/PersistentLockManager.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/lock/PersistentLockManager.java
@@ -34,7 +34,6 @@ public interface PersistentLockManager {
      * {@link Response} for this specified correlationId, containing the {@link PersistentLockResult}.
      * <p>
      * Example:
-     * <p>
      * 
      * <pre>
      * private void acquireLock(final String lockId) throws Interrupt {

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/txn/TransactionController.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/persistent/txn/TransactionController.java
@@ -27,8 +27,12 @@ public interface TransactionController {
 
     /**
      * Runs a database transaction, i.e. a database connection is aquired and the provided DatabaseTransaction object is
-     * executed
-     * in the scope of a transaction.
+     * executed in the scope of a transaction.
+     * @param <T> return type which is passed back by the succeeded transaction. Might be null if transaction runs without giving a result.
+     * @param txn a database transaction object which will be run by the transaction controller.
+     * @return the result of the transaction if any.
+     * @throws Exception if something goes wrong within the given transaction which is not caught by itself or if something
+     *    goes wrong with the transaction management like getConnection throws an SQLException.
      */
     public <T> T run(final DatabaseTransaction<T> txn) throws Exception;
 
@@ -37,6 +41,11 @@ public interface TransactionController {
      * A database, JMS, or any other connection may be aquired later on in this transaction, but to do so is in the
      * scope of the
      * Transaction object. The TransactionController is just defining the start and end of the transaction.
+     * @param <T> return type which is passed back by the succeeded transaction. Might be null if transaction runs without giving a result.
+     * @param txn a database transaction object which will be run by the transaction controller
+     * @return the result of the transaction if any.
+     * @throws Exception if something goes wrong within the given transaction which is not caught by itself or if something
+     *    goes wrong with the transaction management like getConnection throws an SQLException.
      */
     public <T> T run(final Transaction<T> txn) throws Exception;
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/tranzient/EarlyResponseContainer.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/tranzient/EarlyResponseContainer.java
@@ -38,6 +38,7 @@ public interface EarlyResponseContainer {
      * Puts an early reponse into the container
      *
      * @param response
+     *        the response to be put into the container
      */
     public void put(final Response<?> response);
 
@@ -45,6 +46,7 @@ public interface EarlyResponseContainer {
      * Gets and removes the responses for the provided correlationId if they exists.
      *
      * @param correlationId
+     *        correlationId for which responses shall be get and removed.
      * @return the responses or an empty list if there is no response for the provided correlationId.
      */
     public List<Response<?>> get(final String correlationId);

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/tranzient/TransientPriorityProcessorPool.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/tranzient/TransientPriorityProcessorPool.java
@@ -39,6 +39,10 @@ public class TransientPriorityProcessorPool extends PriorityProcessorPool implem
     /**
      * Creates a new {@link TransientPriorityProcessorPool} with as many worker threads as processors available on the
      * corresponding environment.
+     * @param id
+     *        Unique id of the transient processor pool. Might be specified when creating a workflow or within a workflow
+     *        from {@link Workflow#setProcessorPoolId} to let the workflow be run on this processor pool. (After reaching
+     *        the next checkpoint when already running)
      */
     public TransientPriorityProcessorPool(String id) {
         super(id);

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/util/Backchannel.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/util/Backchannel.java
@@ -43,6 +43,7 @@ public interface Backchannel {
      *        timeunit of timeout
      * @return the response or <code>null</code> in case of a timeout.
      * @throws InterruptedException
+     *         Might be thrown from the internally used CountDownLatch await method.
      */
     public Object wait(String correlationId, long timeout, TimeUnit timeunit) throws InterruptedException;
 

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/util/Queue.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/util/Queue.java
@@ -267,6 +267,8 @@ public class Queue {
      *            object to add to the queue
      * @throws OverflowException
      *             if maximum capacity of queue is reached
+     * @throws ClosedException
+     *             if queue is already closed
      */
     public void enqueue(final Object o) throws OverflowException, ClosedException {
         list.addLastElement(o);
@@ -280,8 +282,11 @@ public class Queue {
      *            0 to disable timeout
      * @return the first queue element
      * @throws TimeoutException
+     *         Thrown if timeout is reached while waiting for data in queue
      * @throws ClosedException
+     *         Thrown if queue is already closed
      * @throws InterruptedException
+     *         Might be thrown by the internally used Java-wait method.
      */
     public Object dequeue(final long timeout) throws TimeoutException, ClosedException, InterruptedException {
         return list.remove(timeout == 0 ? this.timeout : timeout);
@@ -293,8 +298,11 @@ public class Queue {
      * 
      * @return the first queue element
      * @throws TimeoutException
+     *         Thrown if timeout is reached while waiting for data in queue
      * @throws ClosedException
+     *         Thrown if queue is already closed
      * @throws InterruptedException
+     *         Might be thrown by the internally used Java-wait method.
      */
     public Object dequeue() throws TimeoutException, ClosedException, InterruptedException {
         return dequeue(0);
@@ -303,8 +311,11 @@ public class Queue {
     /**
      * @return Return first element of the underlying list or null, if queue is empty.
      * @throws TimeoutException
+     *         Thrown if timeout is reached while waiting for data in queue
      * @throws ClosedException
+     *         Thrown if queue is already closed
      * @throws InterruptedException
+     *         Might be thrown by the internally used Java-wait method.
      */
     public Object dequeueOrNull() throws TimeoutException, ClosedException, InterruptedException {
         return list.removeOrNull();
@@ -313,6 +324,7 @@ public class Queue {
     /**
      * @return First element in the queue
      * @throws EmptyQueueException
+     *         Thrown if queue is empty. Then there is no first element...
      */
     public Object front() throws EmptyQueueException {
         return list.getFirstElement();
@@ -348,6 +360,12 @@ public class Queue {
 
     /**
      * Create the internal list (allow derived classes to supply their own list implementation)
+     * @param capacity
+     *        Capacity of the newly created list
+     * @param verbose
+     *        specify if verbose logging shall be enabled for the new list
+     * @return
+     *        the created new internal list
      */
     protected List createList(int capacity, boolean verbose) {
         return new List(capacity, verbose);

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/wfrepo/FileBasedWorkflowRepository.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/wfrepo/FileBasedWorkflowRepository.java
@@ -87,6 +87,8 @@ public class FileBasedWorkflowRepository extends AbstractWorkflowRepository impl
     /**
      * Sets the list of source archive URLs. The source archives must be ZIP compressed archives, containing COPPER
      * workflows as .java files.
+     * @param sourceArchiveUrls
+     *        urls where workflow class sources reside in
      */
     public void setSourceArchiveUrls(List<String> sourceArchiveUrls) {
         if (sourceArchiveUrls == null)
@@ -96,6 +98,8 @@ public class FileBasedWorkflowRepository extends AbstractWorkflowRepository impl
 
     /**
      * Adds a source archive URL.
+     * @param url
+     *        url to be added
      */
     public void addSourceArchiveUrl(String url) {
         if (url == null)
@@ -104,7 +108,7 @@ public class FileBasedWorkflowRepository extends AbstractWorkflowRepository impl
     }
 
     /**
-     * Returns the configured source archive URL(s).
+     * @return the configured source archive URL(s).
      */
     public List<String> getSourceArchiveUrls() {
         return Collections.unmodifiableList(sourceArchiveUrls);
@@ -113,6 +117,8 @@ public class FileBasedWorkflowRepository extends AbstractWorkflowRepository impl
     /**
      * Sets the list of CompilerOptionsProviders. They are called before compiling the workflow files to append compiler
      * options.
+     * @param compilerOptionsProviders
+     *        Options from those providers are used for compilation.
      */
     public void setCompilerOptionsProviders(List<CompilerOptionsProvider> compilerOptionsProviders) {
         if (compilerOptionsProviders == null)
@@ -122,13 +128,15 @@ public class FileBasedWorkflowRepository extends AbstractWorkflowRepository impl
 
     /**
      * Add a CompilerOptionsProvider. They are called before compiling the workflow files to append compiler options.
+     * @param cop
+     *        Options from this provider are used for compilation.
      */
     public void addCompilerOptionsProvider(CompilerOptionsProvider cop) {
         this.compilerOptionsProviders.add(cop);
     }
 
     /**
-     * Returns the currently configured compiler options providers.
+     * @return the currently configured compiler options providers.
      */
     public List<CompilerOptionsProvider> getCompilerOptionsProviders() {
         return Collections.unmodifiableList(compilerOptionsProviders);
@@ -147,6 +155,8 @@ public class FileBasedWorkflowRepository extends AbstractWorkflowRepository impl
 
     /**
      * Configures the local directory/directories that contain the COPPER workflows as <code>.java</code> files.
+     * @param sourceDirs
+     *         List of those source directories
      */
     public void setSourceDirs(List<String> sourceDirs) {
         if (sourceDirs == null)
@@ -156,6 +166,8 @@ public class FileBasedWorkflowRepository extends AbstractWorkflowRepository impl
 
     /**
      * Configures the local directory/directories that contain the COPPER workflows as <code>.java</code> files.
+     * @param sourceDirs
+     *         List of those source directories
      */
     public void setSourceDirs(String... sourceDirs) {
         if (sourceDirs == null)
@@ -164,16 +176,17 @@ public class FileBasedWorkflowRepository extends AbstractWorkflowRepository impl
     }
 
     /**
-     * Returns the configured local directory/directories
+     * @return the configured local directory/directories
      */
     public List<String> getSourceDirs() {
         return Collections.unmodifiableList(sourceDirs);
     }
 
     /**
-     * If true (which is the default), this workflow repository's class loader will also load non-workflow classes, e.g.
-     * inner classes or helper classes. As this is maybe not always useful, use this property to enable or disable this
-     * feature.
+     * @param loadNonWorkflowClasses
+     *        If true (which is the default), this workflow repository's class loader will also load non-workflow classes, e.g.
+     *        inner classes or helper classes. As this is maybe not always useful, use this property to enable or disable this
+     *        feature.
      */
     public void setLoadNonWorkflowClasses(boolean loadNonWorkflowClasses) {
         this.loadNonWorkflowClasses = loadNonWorkflowClasses;
@@ -182,6 +195,10 @@ public class FileBasedWorkflowRepository extends AbstractWorkflowRepository impl
     /**
      * The target directory where COPPER will store the compiled workflow classes (mandatory). Must point to a local
      * directory with read/write privileges.
+     * <b>Note:</b> On repository startup, this directory will be deleted and created freshly. So make sure, there are
+     * no other files in there but only compilation results from COPPER.
+     * @param targetDir
+     *        the target dir.
      */
     public void setTargetDir(String targetDir) {
         this.targetDir = targetDir;
@@ -617,6 +634,8 @@ public class FileBasedWorkflowRepository extends AbstractWorkflowRepository impl
     /**
      * Sets the list of compiler options. They are called before compiling the workflow files to append compiler
      * options (internally invokes {@link FileBasedWorkflowRepository#setCompilerOptionsProviders(List)}.
+     * @param options
+     *        list of options to be set for the compiler.
      */
     public void setCompilerOptions(String... options) {
         List<CompilerOptionsProvider> compilerOptionsProviders = new ArrayList<>();

--- a/projects/copper-ext/src/main/java/org/copperengine/ext/persistent/RdbmsEngineFactory.java
+++ b/projects/copper-ext/src/main/java/org/copperengine/ext/persistent/RdbmsEngineFactory.java
@@ -69,6 +69,7 @@ import com.google.common.base.Suppliers;
  * @author austermann
  *
  * @param <T>
+ *        type of DependencyInjector which shall be used from the created engine
  */
 public abstract class RdbmsEngineFactory<T extends DependencyInjector> extends AbstractPersistentEngineFactory<T> {
 

--- a/projects/copper-ext/src/main/java/org/copperengine/ext/wfrepo/classpath/ClasspathWorkflowRepository.java
+++ b/projects/copper-ext/src/main/java/org/copperengine/ext/wfrepo/classpath/ClasspathWorkflowRepository.java
@@ -59,7 +59,6 @@ import com.google.common.reflect.ClassPath;
  * deployed workflows. Anyhow, this workflow repo is probably suitable for most simple COPPER applications.
  * <p>
  * See ClasspathWorkflowRepositoryTest.java testExec() for sample usage.
- * <p>
  * 
  * <pre>
  * {

--- a/projects/copper-jmx-interface/src/main/java/org/copperengine/management/DatabaseDialectMXBean.java
+++ b/projects/copper-jmx-interface/src/main/java/org/copperengine/management/DatabaseDialectMXBean.java
@@ -22,7 +22,7 @@ public interface DatabaseDialectMXBean {
      * when
      * there is no workflow instance waiting for it within the specified amount of time.
      *
-     * @param defaultStaleResponseRemovalTimeout
+     * @param defaultStaleResponseRemovalTimeout Timeout interval in Milliseconds.
      */
     public void setDefaultStaleResponseRemovalTimeout(long defaultStaleResponseRemovalTimeout);
 

--- a/projects/copper-jmx-interface/src/main/java/org/copperengine/management/FileBasedWorkflowRepositoryMXBean.java
+++ b/projects/copper-jmx-interface/src/main/java/org/copperengine/management/FileBasedWorkflowRepositoryMXBean.java
@@ -20,7 +20,7 @@ import java.util.List;
 public interface FileBasedWorkflowRepositoryMXBean extends WorkflowRepositoryMXBean {
 
     /**
-     * Returns the configured local directory/directories
+     * @return the configured local directory/directories
      */
     public List<String> getSourceDirs();
 

--- a/projects/copper-jmx-interface/src/main/java/org/copperengine/management/PersistentProcessingEngineMXBean.java
+++ b/projects/copper-jmx-interface/src/main/java/org/copperengine/management/PersistentProcessingEngineMXBean.java
@@ -19,16 +19,17 @@ public interface PersistentProcessingEngineMXBean extends ProcessingEngineMXBean
 
     /**
      * Trigger restart a workflow instance that is in the error state.
+     * If workflow id is unknown or the workflow is not in broken state, nothing happens.
      *
-     * @param workflowInstanceId
-     * @throws Exception
+     * @param workflowInstanceId workflow instance id as string
+     * @throws Exception When some database operations fail, i.e. connection lost, transaction problems, ..
      */
     public void restart(String workflowInstanceId) throws Exception;
 
     /**
      * Trigger restart all workflow instances that are in error state.
      *
-     * @throws Exception
+     * @throws Exception When some database operations fail, i.e. connection lost, transaction problems, ..
      */
     public void restartAll() throws Exception;
 

--- a/projects/copper-jmx-interface/src/main/java/org/copperengine/management/ProcessingEngineMXBean.java
+++ b/projects/copper-jmx-interface/src/main/java/org/copperengine/management/ProcessingEngineMXBean.java
@@ -32,7 +32,7 @@ public interface ProcessingEngineMXBean {
     /**
      * Query all <b>currently Running</b> instances from memory only, <b>Note it WON'T return instances in WAITING
      * state</b>
-     * 
+     * @return List of workflow information
      */
     public List<WorkflowInfo> queryWorkflowInstances();
 
@@ -43,20 +43,23 @@ public interface ProcessingEngineMXBean {
      *        - optional, returns workflow instances
      * @param max
      *        - to limit of number of workflows returned
+     * @return List of workflow information
      */
     public List<WorkflowInfo> queryActiveWorkflowInstances(String className, int max);
 
     /**
      * query one workflow instance from memory, <b>Note it WON'T return instances in WAITING state</b>
      * 
-     * @param id
+     * @param id workflow id
+     * @return info about this single workflow (Not if workflow is waiting). null if workflow not found.
      */
     public WorkflowInfo queryWorkflowInstance(String id);
 
     /**
      * query one workflow instance from memory or db regardless of its state
      * 
-     * @param id
+     * @param id workflow id
+     * @return info about this single workflow. null if workflow not found.
      */
     public WorkflowInfo queryActiveWorkflowInstance(String id);
 
@@ -73,7 +76,7 @@ public interface ProcessingEngineMXBean {
     public EngineActivity queryEngineActivity(int minutesInHistory);
     
     /**
-     * Returns a list of all possible workflow instance states
+     * @return a list of all possible workflow instance states
      */
     public List<String> getWorkflowInstanceStates();
     

--- a/projects/copper-jmx-interface/src/main/java/org/copperengine/management/model/EngineActivity.java
+++ b/projects/copper-jmx-interface/src/main/java/org/copperengine/management/model/EngineActivity.java
@@ -40,6 +40,8 @@ public class EngineActivity implements Serializable {
 
     /**
      * Timestamp of the last activity in this engine, e.g. starting a new workflow instance, processing or finishing an existing one.
+     * @return last engine activity timestamp which currently either marks point of last new workflow started or last dependency injection
+     * (Transient: Almost the same as workflow start. Persistent: Equal to continue workflow after checkpoint (Or start workflow))
      */
     public Date getLastActivityTS() {
         return lastActivityTS;
@@ -51,7 +53,7 @@ public class EngineActivity implements Serializable {
 
     /**
      * StartUp TS of this engine or null if the engine is not yet started or down.
-     * @return
+     * @return System time when .startup() was called on the engine.
      */
     public Date getStartupTS() {
         return startupTS;
@@ -62,7 +64,7 @@ public class EngineActivity implements Serializable {
     }
     
     /**
-     * Number of finished Workflow instances within the last N minutes.
+     * @return Number of finished Workflow instances within the last N minutes.
      */
     public long getCountWfiLastNMinutes() {
         return countWfiLastNMinutes;

--- a/projects/copper-spring/src/main/java/org/copperengine/spring/SpringEngineStarter.java
+++ b/projects/copper-spring/src/main/java/org/copperengine/spring/SpringEngineStarter.java
@@ -28,9 +28,6 @@ public class SpringEngineStarter {
 
     private static final Logger logger = LoggerFactory.getLogger(SpringEngineStarter.class);
 
-    /**
-     * @param args
-     */
     public static void main(String[] args) {
         if (args.length == 0) {
             System.out.println("Usage: " + SpringEngineStarter.class.getName() + " <configLocations>");


### PR DESCRIPTION
Mainly just added short descriptions for parameters and return values of functions which were already self explanatory but caused javadoc warnings to be generated as no description was in place...