### PR TITLE
Bugfix: For issue 107 - GitWorkflowRepository.updateLocalGitRepositor…

### DIFF
--- a/WHATSNEW.txt
+++ b/WHATSNEW.txt
@@ -1,3 +1,7 @@
+COPPER 5.2.1
+============
+- Bugfix: For issue 107 - GitWorkflowRepository.updateLocalGitRepositories() fails if credentials are needed (https://github.com/copper-engine/copper-engine/issues/107)
+
 COPPER 5.2.0
 ============
 - New feature: compatible with Java 14

--- a/projects/copper-ext/src/main/java/org/copperengine/ext/wfrepo/git/GitWorkflowRepository.java
+++ b/projects/copper-ext/src/main/java/org/copperengine/ext/wfrepo/git/GitWorkflowRepository.java
@@ -125,6 +125,13 @@ public class GitWorkflowRepository extends FileBasedWorkflowRepository implement
     }
 
     /**
+     * @return the current branch
+     */
+    public synchronized String getBranch() {
+        return branch;
+    }
+
+    /**
      * The current originUri is changed.
      *
      * * If the GitWorkflowRepository {@link #isUp()} isUp the a refesh incl. directory deletion is performed.
@@ -253,7 +260,7 @@ public class GitWorkflowRepository extends FileBasedWorkflowRepository implement
                         .setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.TRACK)
                         .call();
                 logger.debug("Pull repository {}", repository);
-                git.pull().setRemote(ORIGIN).setRemoteBranchName(branch).call();
+                git.pull().setRemote(ORIGIN).setCredentialsProvider(credentialsProvider).setRemoteBranchName(branch).call();
                 logger.debug("Local repository {} found. Again checkout branch {} force.", repository, branch);
                 git.checkout()
                         .setName(ORIGIN + "/" + branch)

--- a/projects/copper-ext/src/test/java/org/copperengine/ext/wfrepo/git/GitWorkflowRepositoryTest.java
+++ b/projects/copper-ext/src/test/java/org/copperengine/ext/wfrepo/git/GitWorkflowRepositoryTest.java
@@ -105,6 +105,7 @@ public class GitWorkflowRepositoryTest {
         engine.run("Workflow1", "foo");
         String result = (String) channel.wait("correlationId", 1000, TimeUnit.MILLISECONDS);
         assertEquals("Vmaster", result);
+        assertEquals("master", wfRepo.getBranch());
     }
 
     @Test


### PR DESCRIPTION
…ies() fails if credentials are needed (https://github.com/copper-engine/copper-engine/issues/107)