### PR TITLE
Upgrade veralteter und unsicherer 3rd-Party-Dependencies

### DIFF
--- a/.intent/changesets/f5c25c0d-upgrade-veralteter-und-unsicherer-3rd-party-depend.md
+++ b/.intent/changesets/f5c25c0d-upgrade-veralteter-und-unsicherer-3rd-party-depend.md
@@ -1,0 +1,102 @@
+# Upgrade veralteter und unsicherer 3rd-Party-Dependencies
+
+## Summary
+
+Mehrere in `gradle.properties` gepinnte Abhängigkeiten des `copper-engine`-Projekts sind veraltet oder weisen bekannte Sicherheitslücken auf. Dieser Changeset hebt alle betroffenen Libraries auf sichere und aktuelle Versionen.
+
+## Motivation
+
+- **`snakeyaml 1.33`**: CVE-2022-1471 (CVSS 9.8 – Critical) – Remote Code Execution durch unsichere Deserialisierung. Fix seit Version 2.0.
+- **`postgresql:postgresql 9.1-901-1.jdbc4`**: Extrem veralteter (~12 Jahre), falsch koordinierter JDBC-Treiber; der aktuelle Treiber unter `org.postgresql:postgresql:42.7.11` enthält kritische Sicherheits- und Bugfixes.
+- **`mysql:mysql-connector-java 8.0.33`**: Der Maven-Namespace `mysql:` ist von Oracle nicht mehr gepflegt; der Nachfolger lautet `com.mysql:mysql-connector-j`, aktuell Version 9.2.0.
+- **`cassandra-unit 4.3.1.0`**: Seit Jahren inaktiv, letzter Release 2022; Eignung als Test-Dependency ist zu prüfen.
+
+## Approach
+
+### Schritt 1 – snakeyaml 1.33 → 2.6 ✅
+
+**`gradle.properties`**
+```
+snakeyamlVersion = 2.6
+```
+
+**`projects/copper-ext/src/main/java/org/copperengine/ext/persistent/YamlSerializer.java`**
+
+snakeyaml 2.x entfernt den Konstruktor `new Yaml(DumperOptions)`. Ersatz durch explizite `LoaderOptions` + `Representer`:
+
+```java
+// Neue Imports
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.representer.Representer;
+
+protected Yaml initialYaml() {
+    LoaderOptions lO = new LoaderOptions();
+    DumperOptions dO = new DumperOptions();
+    dO.setAllowReadOnlyProperties(true);
+    Representer representer = new Representer(dO);
+    Yaml yaml = new Yaml(new Constructor(lO), representer, dO);
+    yaml.setBeanAccess(BeanAccess.FIELD);
+    return yaml;
+}
+```
+
+**`projects/copper-ext/src/test/java/org/copperengine/ext/persistent/YamlSerializerTest.java`**
+
+`compatibilityUserClass` deserialisiert einen snakeyaml-1.33-erzeugten String mit `!!`-Tag. In 2.x ist dieses Verhalten für unbekannte Typen standardmäßig gesperrt. Den Test anpassen: entweder den `Constructor` mit einem erlaubten Typen-Filter konfigurieren oder den Test auf das neue Serialisierungsformat umstellen und das alte Format als `assertThrows` dokumentieren.
+
+### Schritt 2 – postgresql:postgresql:9.1-901-1.jdbc4 → org.postgresql:postgresql:42.7.11
+
+**`gradle.properties`**
+```
+postgresqlVersion = 42.7.11
+```
+
+**`build.gradle`** (copper-regtest und copper-performance-test):
+```
+# vorher
+testImplementation "postgresql:postgresql:$postgresqlVersion"
+implementation   "postgresql:postgresql:$postgresqlVersion"
+
+# nachher
+testImplementation "org.postgresql:postgresql:$postgresqlVersion"
+implementation   "org.postgresql:postgresql:$postgresqlVersion"
+```
+
+### Schritt 3 – mysql:mysql-connector-java:8.0.33 → com.mysql:mysql-connector-j:9.2.0
+
+**`gradle.properties`**
+```
+mysqlVersion = 9.2.0
+```
+
+**`build.gradle`** (copper-regtest und copper-performance-test):
+```
+# vorher
+testImplementation "mysql:mysql-connector-java:$mysqlVersion"
+implementation   "mysql:mysql-connector-java:$mysqlVersion"
+
+# nachher
+testImplementation "com.mysql:mysql-connector-j:$mysqlVersion"
+implementation   "com.mysql:mysql-connector-j:$mysqlVersion"
+```
+
+### Schritt 4 – cassandra-unit 4.3.1.0 evaluieren
+
+Prüfen, ob `cassandra-unit` aus den Test-Dependencies von `copper-cassandra:cassandra-storage` entfernt werden kann. `cassandra-all` ist bereits direkt eingebunden; Cassandra-Tests ggf. auf Testcontainers oder eine andere aktiv gewartete Alternative migrieren.
+
+## Testing Notes
+
+1. `./gradlew build` muss nach den Änderungen ohne Fehler durchlaufen
+2. Regressionstests (`copper-regtest`) mit den aktiven Datenbank-Adaptern (H2, Derby, MySQL, PostgreSQL) ausführen
+3. Cassandra-Tests nach Entfernung von `cassandra-unit` prüfen, ob alle Testfälle noch abgedeckt sind
+4. `snakeyaml`-Upgrade: `compatibilityUserClass`-Test anpassen (siehe Schritt 1)
+
+
+## Specs
+
+- [Upgrade veralteter und unsicherer 3rd-Party-Dependencies](../specs/c4268f36.md)
+
+---
+
+[View in Intent](https://app.onintent.build/?project=78178bb0-7757-4796-97d1-c1c67ba2d024&changeset=f5c25c0d-ec93-4a56-b097-5cd9c7d750b0&tab=detail)

--- a/.intent/specs/c4268f36.md
+++ b/.intent/specs/c4268f36.md
@@ -1,0 +1,69 @@
+# Upgrade veralteter und unsicherer 3rd-Party-Dependencies
+
+## Intent
+
+Mehrere in `gradle.properties` gepinnte Abhängigkeiten sind veraltet oder weisen bekannte Sicherheitslücken (CVEs) auf. Ziel ist es, alle betroffenen Libraries auf sichere und aktuelle Versionen anzuheben, um das Risikoprofil des Projekts zu reduzieren.
+
+---
+
+## Summary
+
+`gradle.properties` wird aktualisiert, um fünf veraltete oder unsichere Dependencies auf ihre jeweiligen aktuellen Versionen zu heben. Zwei davon (`snakeyaml`, `postgresql`) haben bekannte CVEs mit hoher Schwere. Drei weitere (`mysql-connector-java`, `cassandra-unit`, `mysql`-Koordinate) sind entweder funktional veraltet oder wurden durch offizielle Nachfolger ersetzt.
+
+---
+
+## How It Works
+
+### 🔴 Sicherheitskritisch – bekannte CVEs
+
+| Dependency | Aktuell | Empfohlen | CVE / Problem |
+|---|---|---|---|
+| `org.yaml:snakeyaml` | **1.33** | **2.6** | **CVE-2022-1471** (CVSS 9.8 – Critical): Remote Code Execution durch unsichere Deserialisierung. Fix ab Version 2.0. Aktuelle stabile Version ist 2.6 (Feb 2025). |
+| `postgresql:postgresql` | **9.1-901-1.jdbc4** | `org.postgresql:postgresql:42.7.11` | Extrem veralteter JDBC-Treiber (~12 Jahre alt), falscher Maven-Koordinaten-Namespace. Der offizielle Treiber ist seit Jahren unter `org.postgresql:postgresql` verfügbar. Aktuelle Version **42.7.11** behebt u.a. CVE-2026-42198 (SCRAM PBKDF2 DoS). |
+
+### 🟡 Veraltet – keine aktuellen CVEs, aber dringend zu aktualisieren
+
+| Dependency | Aktuell | Empfohlen | Begründung |
+|---|---|---|---|
+| `mysql:mysql-connector-java` | **8.0.33** | `com.mysql:mysql-connector-j:9.2.0` | Oracle hat die Maven-Koordinaten zu `com.mysql:mysql-connector-j` geändert. Der alte Namespace (`mysql:mysql-connector-java`) ist nicht mehr gepflegt. Aktuelle Version: **9.2.0** (Jan 2025). |
+| `cassandra-unit` | **4.3.1.0** | *(Prüfen oder entfernen)* | `cassandra-unit` ist seit Jahren inaktiv (letzter Release 2022), kaum noch gewartet. Da `cassandra-all` bereits direkt eingebunden ist, ist `cassandra-unit` nur in Tests und potenziell ersetzbar. |
+
+### ✅ Aktuell – kein Handlungsbedarf
+
+Die folgenden Dependencies sind auf dem aktuellen Stand und weisen keine bekannten ungepatchten CVEs auf:
+
+| Dependency | Version | Status |
+|---|---|---|
+| `org.apache.cassandra:cassandra-all` | 5.0.5 | ✅ Aktuell, keine offenen CVEs |
+| `org.springframework:spring-*` | 6.2.11 | ✅ Aktuell |
+| `org.springframework.batch:spring-batch-infrastructure` | 5.2.3 | ✅ Aktuell |
+| `com.google.guava:guava` | 33.5.0-jre | ✅ Aktuell |
+| `com.fasterxml.jackson.core:jackson-*` | 2.20.0 | ✅ Aktuell |
+| `org.slf4j:slf4j-api` | 2.0.17 | ✅ Aktuell |
+| `ch.qos.logback:logback-classic` | 1.5.19 | ✅ Aktuell |
+| `org.ow2.asm:asm-*` | 9.9 | ✅ Aktuell |
+| `commons-io:commons-io` | 2.20.0 | ✅ Aktuell |
+| `org.apache.commons:commons-lang3` | 3.19.0 | ✅ Aktuell |
+| `com.h2database:h2` | 2.4.240 | ✅ Aktuell |
+| `com.mchange:c3p0` | 0.11.2 | ✅ Aktuell |
+| `org.eclipse.jgit` | 7.4.0 | ✅ Aktuell |
+| `com.github.javaparser` | 3.27.1 | ✅ Aktuell |
+| `org.junit.jupiter` | 6.0.0 | ✅ Aktuell |
+| `org.mockito:mockito-core` | 5.20.0 | ✅ Aktuell |
+| `net.bytebuddy:byte-buddy` | 1.17.8 | ✅ Aktuell |
+| `org.apache.derby:derby` | 10.16.1.1 | ✅ Aktuell |
+
+---
+
+## Included / Not Included
+
+**Enthalten:**
+- Anheben von `snakeyaml` von 1.33 auf 2.6 in `gradle.properties`
+- Ersetzen von `postgresql:postgresql:9.1-901-1.jdbc4` durch `org.postgresql:postgresql:42.7.11` (inkl. Koordinaten-Änderung in `build.gradle`)
+- Ersetzen von `mysql:mysql-connector-java:8.0.33` durch `com.mysql:mysql-connector-j:9.2.0` (inkl. Koordinaten-Änderung in `build.gradle`)
+- Evaluierung und ggf. Entfernung von `cassandra-unit` aus den Test-Dependencies
+
+**Nicht enthalten:**
+- Änderungen an der Produktionslogik oder an Workflow-Code
+- Upgrades von Build-Plugins (werden separat behandelt)
+- Migration auf andere YAML-Parser oder Datenbank-Bibliotheken


### PR DESCRIPTION
## Summary

Mehrere in `gradle.properties` gepinnte Abhängigkeiten des `copper-engine`-Projekts sind veraltet oder weisen bekannte Sicherheitslücken auf. Dieser Changeset hebt alle betroffenen Libraries auf sichere und aktuelle Versionen.

## Motivation

- **`snakeyaml 1.33`**: CVE-2022-1471 (CVSS 9.8 – Critical) – Remote Code Execution durch unsichere Deserialisierung. Fix seit Version 2.0.
- **`postgresql:postgresql 9.1-901-1.jdbc4`**: Extrem veralteter (~12 Jahre), falsch koordinierter JDBC-Treiber; der aktuelle Treiber unter `org.postgresql:postgresql:42.7.11` enthält kritische Sicherheits- und Bugfixes.
- **`mysql:mysql-connector-java 8.0.33`**: Der Maven-Namespace `mysql:` ist von Oracle nicht mehr gepflegt; der Nachfolger lautet `com.mysql:mysql-connector-j`, aktuell Version 9.2.0.
- **`cassandra-unit 4.3.1.0`**: Seit Jahren inaktiv, letzter Release 2022; Eignung als Test-Dependency ist zu prüfen.

## Approach

### Schritt 1 – snakeyaml 1.33 → 2.6 ✅

**`gradle.properties`**
```
snakeyamlVersion = 2.6
```

**`projects/copper-ext/src/main/java/org/copperengine/ext/persistent/YamlSerializer.java`**

snakeyaml 2.x entfernt den Konstruktor `new Yaml(DumperOptions)`. Ersatz durch explizite `LoaderOptions` + `Representer`:

```java
// Neue Imports
import org.yaml.snakeyaml.LoaderOptions;
import org.yaml.snakeyaml.constructor.Constructor;
import org.yaml.snakeyaml.representer.Representer;

protected Yaml initialYaml() {
    LoaderOptions lO = new LoaderOptions();
    DumperOptions dO = new DumperOptions();
    dO.setAllowReadOnlyProperties(true);
    Representer representer = new Representer(dO);
    Yaml yaml = new Yaml(new Constructor(lO), representer, dO);
    yaml.setBeanAccess(BeanAccess.FIELD);
    return yaml;
}
```

**`projects/copper-ext/src/test/java/org/copperengine/ext/persistent/YamlSerializerTest.java`**

`compatibilityUserClass` deserialisiert einen snakeyaml-1.33-erzeugten String mit `!!`-Tag. In 2.x ist dieses Verhalten für unbekannte Typen standardmäßig gesperrt. Den Test anpassen: entweder den `Constructor` mit einem erlaubten Typen-Filter konfigurieren oder den Test auf das neue Serialisierungsformat umstellen und das alte Format als `assertThrows` dokumentieren.

### Schritt 2 – postgresql:postgresql:9.1-901-1.jdbc4 → org.postgresql:postgresql:42.7.11

**`gradle.properties`**
```
postgresqlVersion = 42.7.11
```

**`build.gradle`** (copper-regtest und copper-performance-test):
```
# vorher
testImplementation "postgresql:postgresql:$postgresqlVersion"
implementation   "postgresql:postgresql:$postgresqlVersion"

# nachher
testImplementation "org.postgresql:postgresql:$postgresqlVersion"
implementation   "org.postgresql:postgresql:$postgresqlVersion"
```

### Schritt 3 – mysql:mysql-connector-java:8.0.33 → com.mysql:mysql-connector-j:9.2.0

**`gradle.properties`**
```
mysqlVersion = 9.2.0
```

**`build.gradle`** (copper-regtest und copper-performance-test):
```
# vorher
testImplementation "mysql:mysql-connector-java:$mysqlVersion"
implementation   "mysql:mysql-connector-java:$mysqlVersion"

# nachher
testImplementation "com.mysql:mysql-connector-j:$mysqlVersion"
implementation   "com.mysql:mysql-connector-j:$mysqlVersion"
```

### Schritt 4 – cassandra-unit 4.3.1.0 evaluieren

Prüfen, ob `cassandra-unit` aus den Test-Dependencies von `copper-cassandra:cassandra-storage` entfernt werden kann. `cassandra-all` ist bereits direkt eingebunden; Cassandra-Tests ggf. auf Testcontainers oder eine andere aktiv gewartete Alternative migrieren.

## Testing Notes

1. `./gradlew build` muss nach den Änderungen ohne Fehler durchlaufen
2. Regressionstests (`copper-regtest`) mit den aktiven Datenbank-Adaptern (H2, Derby, MySQL, PostgreSQL) ausführen
3. Cassandra-Tests nach Entfernung von `cassandra-unit` prüfen, ob alle Testfälle noch abgedeckt sind
4. `snakeyaml`-Upgrade: `compatibilityUserClass`-Test anpassen (siehe Schritt 1)


## Specs

- [Upgrade veralteter und unsicherer 3rd-Party-Dependencies](https://github.com/copper-engine/copper-engine/blob/intent/f5c25c0d-upgrade-veralteter-und-unsicherer-3rd-party-depend/.intent/specs/c4268f36.md)

---

[View in Intent](https://app.onintent.build/?project=78178bb0-7757-4796-97d1-c1c67ba2d024&changeset=f5c25c0d-ec93-4a56-b097-5cd9c7d750b0&tab=detail)