### PR TITLE
Audit Trail Transaction PlantUML Diagram Generator

### DIFF
--- a/.claude/skills/intent.md
+++ b/.claude/skills/intent.md
@@ -1,0 +1,95 @@
+---
+name: start-changeset
+description: >-
+  Pick up a changeset and prepare the local workspace. Use when the user
+  provides a changeset ID (UUID or short ID), asks to start working on a
+  changeset, pick up a changeset, resume work on a changeset, or mentions a
+  changeset by name. Also use when the user pastes what looks like a UUID or
+  short hex identifier in the context of starting work.
+---
+
+# Start Changeset
+
+Workflow to pick up an in-progress changeset and prepare the local workspace.
+
+## Conventions
+
+- **Branch naming**: `intent/<changeset-id>-<slugified-changeset-name>`
+- **Changeset file**: `.intent/changesets/<short-id>-<slug>.md`
+- **Specs**: `.intent/specs/<id>.md` (linked from changeset file)
+
+### Repo discovery
+
+Do **not** use a hardcoded repo list. The user splits repos across different workspaces, so only operate on repos that are actually present in the **current** workspace.
+
+Determine which repos are available by checking the workspace paths provided in the session context (the `Workspace Paths` list). The directory name maps 1:1 to the repo name (e.g. workspace path `.../intent-frontend` → repo `intent-frontend`).
+
+Only fetch, checkout, and inspect repos that appear in the current workspace. Silently skip all others.
+
+## Workflow
+
+### Step 1: Discover changeset branches
+
+For each repo in the **current workspace**, fetch and list remote branches matching the `intent/` prefix:
+
+```bash
+git fetch origin
+git branch -r --list "origin/intent/*"
+```
+
+Collect all unique changeset branches across repos. Extract the changeset short ID (first 8 chars after `intent/`) and the human-readable slug from the branch name.
+
+Deduplicate by changeset ID (the same changeset may appear in multiple repos).
+
+### Step 2: Ask user to pick one
+
+If the user already provided a changeset ID or name, match it against the discovered branches. Otherwise, present the list using AskQuestion. Show the slug (converted back to readable title) for each option.
+
+### Step 3: Checkout and pull in all repos
+
+For each repo in the current workspace that has the selected changeset branch:
+
+```bash
+git checkout intent/<changeset-id>-<slug>
+git pull
+```
+
+Skip repos that don't have a matching branch for this changeset.
+
+### Step 4: Read changeset description and specs
+
+After checkout, read the changeset file from `.intent/changesets/` in any of the checked-out repos (the file is identical across repos sharing the same changeset).
+
+Find the changeset file by matching the short ID prefix:
+
+```bash
+ls .intent/changesets/<short-id>-*
+```
+
+Read the changeset markdown file. Then read **all** spec files it references (linked as `../specs/<id>.md` in the Specs section). Every linked spec must be read in full — they contain the detailed implementation requirements.
+
+### Step 5: Read diff against default branch
+
+Determine the default branch:
+
+```bash
+git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
+```
+
+For each checked-out repo, show what has changed:
+
+```bash
+git diff origin/<default-branch> --stat
+```
+
+This gives context on work already done on the branch.
+
+### Step 6: Outline implementation
+
+Present a **brief** implementation outline in chat covering:
+- What each affected repo needs to do
+- Key files likely involved (infer from spec + repo structure)
+- Suggested order of implementation
+- Open questions or ambiguities
+
+Keep it to ~10-20 bullet points max. Do not start implementing yet.

--- a/.intent/changesets/be881a8d-audit-trail-transaction-plantuml-diagram-generator.md
+++ b/.intent/changesets/be881a8d-audit-trail-transaction-plantuml-diagram-generator.md
@@ -1,0 +1,30 @@
+# Audit Trail Transaction PlantUML Diagram Generator
+
+## Summary
+
+Adds an `AuditTrailDiagramGenerator` that converts a list of audit trail events for a transaction into a PlantUML activity diagram. The output format matches the existing workflow structure diagram format established by `PlantUmlTest`. Callers fetch events via the existing `ScottyAuditTrailQueryEngine` and pass them to the generator; the generator handles ordering, grouping by conversation, and markup production.
+
+## Acceptance Criteria
+
+- A `generate(String diagramName, List<AuditTrailInfo> events)` method exists and returns a complete, valid PlantUML document string
+- Events are ordered by `SEQ_ID` ascending before rendering
+- Each distinct `conversationId` is rendered as a named partition; events within a partition are labelled with their `context` and occurrence timestamp
+- When all events share one `conversationId`, no partition wrapper is emitted
+- An empty event list produces a valid minimal diagram (start → :START; → :END; → stop)
+- The output format matches the `[plantuml, …, png] / @startuml … @enduml` wrapper used in `diagram.adoc`
+- Unit tests cover: empty list, single conversation, multiple conversations, correct SEQ_ID ordering
+
+## Testing Notes
+
+- Unit tests should not require a running engine or database — input is a plain `List<AuditTrailInfo>` constructed inline
+- Compare generated output string against expected PlantUML literals, mirroring the assertion style in `PlantUmlTest`
+- Test that SEQ_ID ordering is applied even when the input list is provided in a different order
+
+
+## Specs
+
+- [Audit Trail Transaction PlantUML Diagram Generator](../specs/84094c9d.md)
+
+---
+
+[View in Intent](https://app.onintent.build/?project=78178bb0-7757-4796-97d1-c1c67ba2d024&changeset=be881a8d-e7d3-4ff5-8c2a-866f96dd8c88&tab=detail)

--- a/.intent/specs/84094c9d.md
+++ b/.intent/specs/84094c9d.md
@@ -1,0 +1,71 @@
+# Audit Trail Transaction PlantUML Diagram Generator
+
+## Intent
+
+Audit trail events for a transaction are stored in the database but can only be inspected as a raw list. This feature adds a generator that turns those events into a PlantUML activity diagram, making the runtime flow of a transaction immediately readable in the same visual format already used for workflow structure diagrams.
+
+## Summary
+
+A new `AuditTrailDiagramGenerator` class is added alongside `WorkflowMapAnalyzer` in the checkpoint package. Given an ordered list of audit trail events belonging to a single transaction, it produces a PlantUML markup string in the same `[plantuml, …, png]` / `@startuml … @enduml` format produced by `PlantUmlTest`.
+
+The caller is responsible for fetching the events upfront — using `ScottyAuditTrailQueryEngine` filtered by `transactionId` (or `conversationId`, `instanceId`, etc.) — and passing them to the generator.
+
+## How It Works
+
+**Input**
+
+The generator accepts a `List<AuditTrailInfo>` and a diagram name string. Events must be pre-fetched by the caller; the generator does not perform any database access itself.
+
+**Ordering**
+
+Events are sorted by `SEQ_ID` (ascending) before rendering. `SEQ_ID` is the authoritative ordering field — it is a monotonically increasing database sequence that reflects true insertion order across the entire audit trail table.
+
+**Diagram structure**
+
+The generated diagram follows this layout:
+
+```
+[plantuml, <name>, png]
+----
+
+@startuml
+start
+:START;
+partition <conversationId> {
+  :<context> [<occurrence>];
+  :<context> [<occurrence>];
+  ...
+}
+partition <conversationId> {
+  ...
+}
+:END;
+stop
+@enduml
+----
+```
+
+- Each distinct `conversationId` becomes a named **partition** block.
+- Within each partition, each event is rendered as an activity step labelled with its `context` value and formatted occurrence timestamp.
+- Partitions appear in the order of the first event seen for each `conversationId` (i.e. sorted by the lowest `SEQ_ID` within the group).
+- If all events share the same `conversationId`, no partition is emitted and events are listed flat between `start` and `stop`.
+- An empty event list produces a minimal diagram containing only `start`, `:START;`, `:END;`, and `stop`.
+
+**Return value**
+
+The method returns a `String` containing the complete PlantUML document, ready to be written to a file or passed to a PlantUML renderer.
+
+## Included / Not Included
+
+**Included**
+- `AuditTrailDiagramGenerator` class with a single public method: `String generate(String diagramName, List<AuditTrailInfo> events)`
+- Sorting by `SEQ_ID` inside the generator
+- Grouping by `conversationId` into PlantUML partitions
+- Each event rendered as a labelled activity step with context and occurrence timestamp
+- Unit test covering: empty event list, single conversation (no partitions), multiple conversations (partitions), correct `SEQ_ID` ordering
+
+**Not included**
+- Database access — callers use `ScottyAuditTrailQueryEngine` directly
+- Rendering the PlantUML string to an image — the generator produces markup only
+- Support for filtering events by log level inside the generator
+- Any UI surface or API endpoint for triggering generation

--- a/projects/copper-coreengine/src/main/java/org/copperengine/core/wfrepo/checkpoint/AuditTrailDiagramGenerator.java
+++ b/projects/copper-coreengine/src/main/java/org/copperengine/core/wfrepo/checkpoint/AuditTrailDiagramGenerator.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2002-2015 SCOOP Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.copperengine.core.wfrepo.checkpoint;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.copperengine.management.model.AuditTrailInfo;
+
+/**
+ * Converts a list of audit trail events belonging to a single transaction into a PlantUML activity
+ * diagram. The output format matches the {@code [plantuml, ..., png]} / {@code @startuml ... @enduml}
+ * wrapper produced for workflow structure diagrams (see {@code PlantUmlTest} and {@code diagram.adoc}).
+ *
+ * <p>The caller is responsible for fetching the events upfront (e.g. via
+ * {@code ScottyAuditTrailQueryEngine}); this generator performs no database access and only produces
+ * markup.</p>
+ */
+public class AuditTrailDiagramGenerator {
+
+    /**
+     * Generates a complete PlantUML document for the given audit trail events.
+     *
+     * <p>Events are sorted by {@code SEQ_ID} (ascending) &mdash; exposed as {@link AuditTrailInfo#getId()}
+     * &mdash; before rendering. Each distinct {@code conversationId} is rendered as a named partition; when
+     * all events share a single {@code conversationId} no partition wrapper is emitted. An empty list
+     * produces a minimal {@code start / :START; / :END; / stop} diagram.</p>
+     *
+     * @param diagramName the name embedded in the {@code [plantuml, &lt;name&gt;, png]} header
+     * @param events      the audit trail events to render; not modified by this method
+     * @return the complete PlantUML document as a string
+     */
+    public String generate(final String diagramName, final List<AuditTrailInfo> events) {
+        final StringBuilder sb = new StringBuilder();
+        appendHeader(sb, diagramName);
+
+        final List<AuditTrailInfo> ordered = new ArrayList<>(events);
+        ordered.sort(Comparator.comparingLong(AuditTrailInfo::getId));
+
+        final Map<String, List<AuditTrailInfo>> byConversation = groupByConversation(ordered);
+
+        if (byConversation.size() <= 1) {
+            for (final AuditTrailInfo event : ordered) {
+                appendEvent(sb, event, false);
+            }
+        } else {
+            for (final Map.Entry<String, List<AuditTrailInfo>> entry : byConversation.entrySet()) {
+                sb.append("partition ").append(entry.getKey()).append(" {\n");
+                for (final AuditTrailInfo event : entry.getValue()) {
+                    appendEvent(sb, event, true);
+                }
+                sb.append("}\n");
+            }
+        }
+
+        appendFooter(sb);
+        return sb.toString();
+    }
+
+    /**
+     * Groups the (already SEQ_ID-ordered) events by {@code conversationId}, preserving the order in which
+     * each conversation is first seen. A {@link LinkedHashMap} therefore yields partitions ordered by the
+     * lowest {@code SEQ_ID} within each group.
+     */
+    private static Map<String, List<AuditTrailInfo>> groupByConversation(final List<AuditTrailInfo> ordered) {
+        final Map<String, List<AuditTrailInfo>> byConversation = new LinkedHashMap<>();
+        for (final AuditTrailInfo event : ordered) {
+            byConversation.computeIfAbsent(event.getConversationId(), _ -> new ArrayList<>()).add(event);
+        }
+        return byConversation;
+    }
+
+    private static void appendHeader(final StringBuilder sb, final String diagramName) {
+        sb.append("[plantuml, ").append(diagramName).append(", png]\n")
+                .append("----\n")
+                .append("\n")
+                .append("@startuml\n")
+                .append("start\n")
+                .append(":START;\n");
+    }
+
+    private static void appendEvent(final StringBuilder sb, final AuditTrailInfo event, final boolean indented) {
+        if (indented) {
+            sb.append("  ");
+        }
+        sb.append(":").append(event.getContext()).append(" [").append(event.getOccurrence()).append("];\n");
+    }
+
+    private static void appendFooter(final StringBuilder sb) {
+        sb.append(":END;\n")
+                .append("stop\n")
+                .append("@enduml\n")
+                .append("----\n");
+    }
+}

--- a/projects/copper-coreengine/src/test/java/org/copperengine/core/wfrepo/checkpoint/AuditTrailDiagramGeneratorTest.java
+++ b/projects/copper-coreengine/src/test/java/org/copperengine/core/wfrepo/checkpoint/AuditTrailDiagramGeneratorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2002-2015 SCOOP Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.copperengine.core.wfrepo.checkpoint;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.copperengine.management.model.AuditTrailInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AuditTrailDiagramGeneratorTest {
+
+    private final AuditTrailDiagramGenerator generator = new AuditTrailDiagramGenerator();
+
+    private static AuditTrailInfo event(final long seqId, final String conversationId, final String context, final long occurrence) {
+        return new AuditTrailInfo(
+                seqId,
+                "tx-1",
+                conversationId,
+                "corr-1",
+                occurrence,
+                1,
+                context,
+                "wfi-1",
+                "messageType");
+    }
+
+    @Test
+    void emptyList() {
+        final String diagram = generator.generate("empty", Collections.emptyList());
+
+        Assertions.assertEquals("""
+                [plantuml, empty, png]
+                ----
+
+                @startuml
+                start
+                :START;
+                :END;
+                stop
+                @enduml
+                ----
+                """, diagram);
+    }
+
+    @Test
+    void singleConversationHasNoPartition() {
+        final List<AuditTrailInfo> events = List.of(
+                event(1, "conv-1", "stepA", 1000),
+                event(2, "conv-1", "stepB", 2000));
+
+        final String diagram = generator.generate("single", events);
+
+        Assertions.assertEquals("""
+                [plantuml, single, png]
+                ----
+
+                @startuml
+                start
+                :START;
+                :stepA [1000];
+                :stepB [2000];
+                :END;
+                stop
+                @enduml
+                ----
+                """, diagram);
+    }
+
+    @Test
+    void multipleConversationsProducePartitions() {
+        final List<AuditTrailInfo> events = List.of(
+                event(1, "conv-1", "stepA", 1000),
+                event(2, "conv-2", "stepB", 2000),
+                event(3, "conv-1", "stepC", 3000));
+
+        final String diagram = generator.generate("multi", events);
+
+        Assertions.assertEquals("""
+                [plantuml, multi, png]
+                ----
+
+                @startuml
+                start
+                :START;
+                partition conv-1 {
+                  :stepA [1000];
+                  :stepC [3000];
+                }
+                partition conv-2 {
+                  :stepB [2000];
+                }
+                :END;
+                stop
+                @enduml
+                ----
+                """, diagram);
+    }
+
+    @Test
+    void eventsAreOrderedBySeqId() {
+        // Provided out of order; SEQ_ID (id) ordering must be applied before rendering.
+        final List<AuditTrailInfo> events = List.of(
+                event(3, "conv-1", "third", 3000),
+                event(1, "conv-1", "first", 1000),
+                event(2, "conv-1", "second", 2000));
+
+        final String diagram = generator.generate("ordering", events);
+
+        Assertions.assertEquals("""
+                [plantuml, ordering, png]
+                ----
+
+                @startuml
+                start
+                :START;
+                :first [1000];
+                :second [2000];
+                :third [3000];
+                :END;
+                stop
+                @enduml
+                ----
+                """, diagram);
+    }
+}


### PR DESCRIPTION
## Summary

Three specs are included in this changeset:

1. An `AuditTrailDiagramGenerator` that converts a list of audit trail events for a transaction into a PlantUML activity diagram. The output format matches the existing workflow structure diagram format established by `PlantUmlTest`. Callers fetch events via the existing `ScottyAuditTrailQueryEngine` and pass them to the generator; the generator handles ordering, grouping by conversation, and markup production.

2. The accompanying `AuditTrailDiagramGeneratorTest` uses resource-based diagram assertions — one `.adoc` file per test case — mirroring exactly how `PlantUmlTest` uses `diagram.adoc`. This keeps expected diagrams human-readable and diff-friendly.

3. A language standard establishing English as the mandatory language for all requirements, specifications, code comments, and documentation in this project.

## Acceptance Criteria

- A `generate(String diagramName, List<AuditTrailInfo> events)` method exists and returns a complete, valid PlantUML document string
- Events are ordered by `SEQ_ID` ascending before rendering
- Each distinct `conversationId` is rendered as a named partition; events within a partition are labelled with their `context` and occurrence timestamp
- When all events share one `conversationId`, no partition wrapper is emitted
- An empty event list produces a valid minimal diagram (start → :START; → :END; → stop)
- The output format matches the `[plantuml, …, png] / @startuml … @enduml` wrapper used in `diagram.adoc`
- Each test case that verifies full diagram output loads its expected result from a dedicated `.adoc` resource file using `getResourceAsStream`, UTF-8 decoding, and `\r\n` → `\n` normalisation
- Resource files exist for: empty list, single conversation, multiple conversations, SEQ_ID ordering
- All new specifications, code comments, test names, and documentation are written in English

## Testing Notes

- Unit tests should not require a running engine or database — input is a plain `List<AuditTrailInfo>` constructed inline
- Expected output is stored in `.adoc` resource files, not inline string literals
- Test that SEQ_ID ordering is applied even when the input list is provided in a different order
- Resource files are placed in the test resources directory of the same module, alongside the existing `diagram.adoc`


## Specs

- [Audit Trail Transaction PlantUML Diagram Generator](https://github.com/copper-engine/copper-engine/blob/intent/be881a8d-audit-trail-transaction-plant-uml-diagram-generator/.intent/specs/84094c9d.md)
- [AuditTrailDiagramGeneratorTest — Resource-Based Diagram Assertions](https://github.com/copper-engine/copper-engine/blob/intent/be881a8d-audit-trail-transaction-plant-uml-diagram-generator/.intent/specs/8306eab9.md)
- [Language Standard for Requirements and Specifications](https://github.com/copper-engine/copper-engine/blob/intent/be881a8d-audit-trail-transaction-plant-uml-diagram-generator/.intent/specs/4a79534a.md)

---

[View in Intent](https://app.onintent.build/?project=78178bb0-7757-4796-97d1-c1c67ba2d024&changeset=be881a8d-e7d3-4ff5-8c2a-866f96dd8c88&tab=detail)