### PR TITLE
AuditTrailDiagramGeneratorTest resource-based expected diagram

### DIFF
--- a/.intent/changesets/1fba57a3-audit-trail-diagram-generator-test-resource-based-expected.md
+++ b/.intent/changesets/1fba57a3-audit-trail-diagram-generator-test-resource-based-expected.md
@@ -1,0 +1,31 @@
+# AuditTrailDiagramGeneratorTest resource-based expected diagram
+
+## Summary
+
+> "For the result diagram in AuditTrailDiagramGeneratorTest, use a resource that is structured like diagram.adoc!"
+
+Replace inline expected-diagram strings in `AuditTrailDiagramGeneratorTest` with dedicated `.adoc` resource files, following the same pattern used by `PlantUmlTest` with `diagram.adoc`. Each test case that asserts a full diagram output loads its expected content from a named resource file instead of a hardcoded string literal.
+
+## Acceptance Criteria
+
+- A dedicated `.adoc` resource file exists for each test case that verifies full diagram output (empty list, single conversation, multiple conversations, SEQ_ID ordering)
+- Each resource file follows the same `[plantuml, …, png] / @startuml … @enduml` structure as `diagram.adoc`
+- Each test case loads its expected diagram via `getResourceAsStream`, UTF-8 decoding, and `\r\n` → `\n` normalisation — matching the `PlantUmlTest` pattern exactly
+- No inline expected-diagram strings remain in the test code for full-diagram assertions
+- Resource files are placed in the test resources directory alongside the existing `diagram.adoc`
+
+## Testing Notes
+
+- Verify each test still passes after replacing inline strings with resource-file loading
+- Confirm that altering a resource file causes the corresponding test to fail (i.e. the comparison is actually exercised)
+
+
+## Specs
+
+- [AuditTrailDiagramGeneratorTest — Resource-Based Expected Diagram](../specs/5dd34fee.md)
+- [audit-trail-diagram-ordered.adoc — Expected Diagram Resource for SEQ_ID Ordering Test](../specs/63b3649e.md)
+- [audit-trail-diagram-ordered.adoc — Expected Diagram Resource for SEQ_ID Ordering Test](../specs/1f2bff60.md)
+
+---
+
+[View in Intent](https://app.onintent.build/?project=78178bb0-7757-4796-97d1-c1c67ba2d024&changeset=1fba57a3-7a7c-4f92-b019-777b794e200e&tab=detail)

--- a/.intent/specs/1f2bff60.md
+++ b/.intent/specs/1f2bff60.md
@@ -1,0 +1,38 @@
+# audit-trail-diagram-ordered.adoc — Expected Diagram Resource for SEQ_ID Ordering Test
+
+## Intent
+
+Provide the expected PlantUML diagram as a dedicated `.adoc` resource file for the test case that verifies correct SEQ_ID ascending ordering of audit trail events.
+
+## Summary
+
+When `AuditTrailDiagramGeneratorTest` verifies that events are rendered in SEQ_ID ascending order — even when the input list is provided in a different order — it must load its expected output from `audit-trail-diagram-ordered.adoc` rather than an inline string.
+
+## How It Works
+
+The file is a plain `.adoc` file placed in the test resources directory alongside `diagram.adoc`. It contains the complete expected PlantUML document for the ordering scenario, structured identically to `diagram.adoc`:
+
+```
+[plantuml, audit-trail-diagram-ordered, png]
+----
+
+@startuml
+start
+:START;
+...
+:END;
+stop
+@enduml
+----
+```
+
+The test loads this file via `getResourceAsStream`, decodes it as UTF-8, normalises line endings (`\r\n` → `\n`), and asserts equality against the actual generator output.
+
+## Included / Not Included
+
+**Included**
+- The `audit-trail-diagram-ordered.adoc` resource file for the SEQ_ID ordering test case
+
+**Not included**
+- Changes to the generator implementation
+- Resource files for any other test case (covered by the parent spec)

--- a/.intent/specs/5dd34fee.md
+++ b/.intent/specs/5dd34fee.md
@@ -1,0 +1,63 @@
+# AuditTrailDiagramGeneratorTest — Resource-Based Expected Diagram
+
+## Intent
+
+Replace any inline expected-diagram strings in `AuditTrailDiagramGeneratorTest` with dedicated `.adoc` resource files, following the same pattern already established by `PlantUmlTest` and `diagram.adoc`. This makes expected diagrams human-readable, diff-friendly, and easy to update without touching test source code.
+
+## Summary
+
+> "For the result diagram in AuditTrailDiagramGeneratorTest, use a resource that is structured like diagram.adoc!"
+
+Each test case that asserts a full diagram output loads its expected content from a named `.adoc` file stored in the test resources directory, rather than comparing against a string literal embedded in the test code. The file format and the loading mechanism mirror `diagram.adoc` exactly.
+
+## How It Works
+
+**Resource file format**
+
+Each file is a plain `.adoc` file containing the complete expected PlantUML document, wrapped in the AsciiDoc block header — identical in structure to `diagram.adoc`:
+
+```
+[plantuml, <diagram-name>, png]
+----
+
+@startuml
+start
+:START;
+...
+:END;
+stop
+@enduml
+----
+```
+
+**One file per test case**
+
+Each scenario that verifies a full diagram output has its own named resource file placed in the test resources directory alongside the existing `diagram.adoc`:
+
+| Test case | Resource file |
+|---|---|
+| Empty event list | `audit-trail-diagram-empty.adoc` |
+| Single conversation | `audit-trail-diagram-single.adoc` |
+| Multiple conversations | `audit-trail-diagram-multi.adoc` |
+| Unordered input (SEQ_ID sort) | `audit-trail-diagram-ordered.adoc` |
+
+**Loading mechanism**
+
+Each test case loads its expected diagram the same way `PlantUmlTest` does:
+
+1. Open the resource file via `getResourceAsStream`
+2. Read all bytes and decode as UTF-8
+3. Normalise line endings (`\r\n` → `\n`)
+4. Assert equality against the actual generated output
+
+## Included / Not Included
+
+**Included**
+- One `.adoc` resource file per test case that asserts a full diagram
+- Loading, UTF-8 decoding, and line-ending normalisation in the test, matching the `PlantUmlTest` pattern
+- Removal of any inline expected-diagram strings from the test code
+
+**Not included**
+- Changes to the diagram generator implementation itself
+- A shared base class or utility for resource loading
+- Resource files for test cases that only check structural properties (null checks, exception types, etc.) rather than full diagram content

--- a/.intent/specs/63b3649e.md
+++ b/.intent/specs/63b3649e.md
@@ -1,0 +1,38 @@
+# audit-trail-diagram-ordered.adoc — Expected Diagram Resource for SEQ_ID Ordering Test
+
+## Intent
+
+Provide the expected PlantUML diagram as a dedicated `.adoc` resource file for the test case that verifies correct SEQ_ID ascending ordering of audit trail events.
+
+## Summary
+
+When `AuditTrailDiagramGeneratorTest` verifies that events are rendered in SEQ_ID ascending order — even when the input list is provided in a different order — it must load its expected output from `audit-trail-diagram-ordered.adoc` rather than an inline string.
+
+## How It Works
+
+The file is a plain `.adoc` file placed in the test resources directory alongside `diagram.adoc`. It contains the complete expected PlantUML document for the ordering scenario, structured identically to `diagram.adoc`:
+
+```
+[plantuml, audit-trail-diagram-ordered, png]
+----
+
+@startuml
+start
+:START;
+...
+:END;
+stop
+@enduml
+----
+```
+
+The test loads this file via `getResourceAsStream`, decodes it as UTF-8, normalises line endings (`\r\n` → `\n`), and asserts equality against the actual generator output.
+
+## Included / Not Included
+
+**Included**
+- The `audit-trail-diagram-ordered.adoc` resource file for the SEQ_ID ordering test case
+
+**Not included**
+- Changes to the generator implementation
+- Resource files for any other test case (covered by the parent spec)


### PR DESCRIPTION
## Summary

> "For the result diagram in AuditTrailDiagramGeneratorTest, use a resource that is structured like diagram.adoc!"

Replace inline expected-diagram strings in `AuditTrailDiagramGeneratorTest` with dedicated `.adoc` resource files, following the same pattern used by `PlantUmlTest` with `diagram.adoc`. Each test case that asserts a full diagram output loads its expected content from a named resource file instead of a hardcoded string literal.

## Acceptance Criteria

- A dedicated `.adoc` resource file exists for each test case that verifies full diagram output (empty list, single conversation, multiple conversations, SEQ_ID ordering)
- Each resource file follows the same `[plantuml, …, png] / @startuml … @enduml` structure as `diagram.adoc`
- Each test case loads its expected diagram via `getResourceAsStream`, UTF-8 decoding, and `\r\n` → `\n` normalisation — matching the `PlantUmlTest` pattern exactly
- No inline expected-diagram strings remain in the test code for full-diagram assertions
- Resource files are placed in the test resources directory alongside the existing `diagram.adoc`

## Testing Notes

- Verify each test still passes after replacing inline strings with resource-file loading
- Confirm that altering a resource file causes the corresponding test to fail (i.e. the comparison is actually exercised)


## Specs

- [AuditTrailDiagramGeneratorTest — Resource-Based Expected Diagram](https://github.com/copper-engine/copper-engine/blob/intent/1fba57a3-audit-trail-diagram-generator-test-resource-based-expected/.intent/specs/5dd34fee.md)
- [audit-trail-diagram-ordered.adoc — Expected Diagram Resource for SEQ_ID Ordering Test](https://github.com/copper-engine/copper-engine/blob/intent/1fba57a3-audit-trail-diagram-generator-test-resource-based-expected/.intent/specs/63b3649e.md)
- [audit-trail-diagram-ordered.adoc — Expected Diagram Resource for SEQ_ID Ordering Test](https://github.com/copper-engine/copper-engine/blob/intent/1fba57a3-audit-trail-diagram-generator-test-resource-based-expected/.intent/specs/1f2bff60.md)

---

[View in Intent](https://app.onintent.build/?project=78178bb0-7757-4796-97d1-c1c67ba2d024&changeset=1fba57a3-7a7c-4f92-b019-777b794e200e&tab=detail)